### PR TITLE
Tabs bind to windowID instead of PID

### DIFF
--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -69,10 +69,10 @@ tabbed.pick = function()
     -- this function uses xprop to grab a client pid which is then 
     -- compared to all other client process ids
 
-    local xprop_cmd = [[ xprop _NET_WM_PID | cut -d' ' -f3 ]]
-    awful.spawn.easy_async_with_shell(xprop_cmd, function(output)
+    local xwininfo_cmd = [[ xwininfo | grep 'xwininfo: Window id:' | cut -d " " -f 4 ]]
+    awful.spawn.easy_async_with_shell(xwininfo_cmd, function(output)
         for _, c in ipairs(client.get()) do
-            if tonumber(c.pid) == tonumber(output) then
+            if tonumber(c.window) == tonumber(output) then
                 tabbed.add(c, tabobj)
             end
         end


### PR DESCRIPTION
Some software like for example Sublime Text 3 has many windows launched under the same `PID`. When I picked one such window with `xprop` it collected all windows from all tags and added them all to a tabgroup.

So, my solution is to use xorg `windowID` instead of `PID` to differentiate client windows and interact with them separately. I use `xwininfo` tool to get `windowID`