### PR TITLE
[tabbar] change PID to windowID + add for both directions of pick/focus 

### DIFF
--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -61,19 +61,28 @@ tabbed.add = function(c, tabobj)
     tabbed.switch_to(tabobj, #tabobj.clients)
 end
 
--- use xprop to select one client and make it tab in the currently focused tab
+-- use xwininfo to select one client and make it tab in the currently focused tab
 tabbed.pick = function()
-    if not client.focus then return end 
-    if not client.focus.bling_tabbed then tabbed.init(client.focus) end
-    local tabobj = client.focus.bling_tabbed
-    -- this function uses xprop to grab a client pid which is then 
-    -- compared to all other client process ids
+    if not client.focus then return end
+    -- this function uses xwininfo to grab a client window id which is then
+    -- compared to all other clients window ids
 
     local xwininfo_cmd = [[ xwininfo | grep 'xwininfo: Window id:' | cut -d " " -f 4 ]]
     awful.spawn.easy_async_with_shell(xwininfo_cmd, function(output)
         for _, c in ipairs(client.get()) do
             if tonumber(c.window) == tonumber(output) then
-                tabbed.add(c, tabobj)
+                if not client.focus.bling_tabbed and not c.bling_tabbed then
+                    tabbed.init(client.focus)
+                    tabbed.add(c, client.focus.bling_tabbed)
+                end
+                if not client.focus.bling_tabbed and c.bling_tabbed then
+                    tabbed.add(client.focus, c.bling_tabbed)
+                end
+                if client.focus.bling_tabbed and not c.bling_tabbed then
+                    tabbed.add(c, client.focus.bling_tabbed)
+                end
+                -- TODO: Should also merge tabs when focus and picked
+                -- both are tab groups
             end
         end
     end)

--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -69,10 +69,10 @@ tabbed.pick = function()
     -- this function uses xprop to grab a client pid which is then 
     -- compared to all other client process ids
 
-    local xprop_cmd = [[ xprop _NET_WM_PID | cut -d' ' -f3 ]]
-    awful.spawn.easy_async_with_shell(xprop_cmd, function(output)
+    local xwininfo_cmd = [[ xwininfo | grep 'xwininfo: Window id:' | cut -d " " -f 4 ]]
+    awful.spawn.easy_async_with_shell(xwininfo_cmd, function(output)
         for _, c in ipairs(client.get()) do
-            if tonumber(c.pid) == tonumber(output) then
+            if tonumber(c.window) == tonumber(output) then
                 tabbed.add(c, tabobj)
             end
         end


### PR DESCRIPTION
With this patch you may:
- from focused single window pick another single wimdow
- from focused single window pick a tabgroup window
- from focused tabgroup window pick a single window

All ways of actions will work exactly the same: single window will be added to a new one or either already existing tabgroup window.