### PR TITLE
Cleanup of some global functions in playerctl lib backend

### DIFF
--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -32,7 +32,7 @@ local interval = 1
 -- Track position callback
 local last_position = -1
 local last_length = -1
-function position_cb()
+local function position_cb()
     local player = manager.players[1]
     if player then
         local position = player:get_position() / 1000000
@@ -74,7 +74,7 @@ local last_player = nil
 local last_title = ""
 local last_artist = ""
 local last_artUrl = ""
-function metadata_cb(player, metadata)
+local function metadata_cb(player, metadata)
     if update_on_activity then
         manager:move_player_to_top(player)
     end
@@ -119,7 +119,7 @@ end
 
 -- Playback status callback
 -- Reported as PLAYING, PAUSED, or STOPPED
-function playback_status_cb(player, status)
+local function playback_status_cb(player, status)
     if update_on_activity then
         manager:move_player_to_top(player)
     end
@@ -134,7 +134,7 @@ function playback_status_cb(player, status)
 end
 
 -- Determine if player should be managed
-function name_is_selected(name)
+local function name_is_selected(name)
     if ignore[name.name] then
         return false
     end
@@ -170,8 +170,8 @@ end
 -- priority order
 local function player_compare_name(name_a, name_b)
     local any_index = math.huge
-    local a_match_index = nil 
-    local b_match_index = nil 
+    local a_match_index = nil
+    local b_match_index = nil
 
     if name_a == name_b then
         return 0
@@ -273,7 +273,7 @@ local function playerctl_enable(args)
     -- Grab playerctl library
     Playerctl = require("lgi").Playerctl
 
-    -- Ensure main event loop has started before starting player manager 
+    -- Ensure main event loop has started before starting player manager
     gears.timer.delayed_call(start_manager)
 end
 


### PR DESCRIPTION
Not sure why I made some of these functions global but they shouldn't be.