### PR TITLE
Adding Close, Minimize and Float buttons in tabbar (again)

### DIFF
--- a/widget/tabbar/modern.lua
+++ b/widget/tabbar/modern.lua
@@ -95,17 +95,33 @@ local function create(c, focused_bool, buttons)
         layout = wibox.layout.align.horizontal
     }
 
+    local close = create_title_button(c, close_color, bg_normal)
+    close:connect_signal("button::press", function() c:kill() end)
+
+    local floating = create_title_button(c, float_color, bg_normal)
+    floating:connect_signal("button::press",
+                            function() c.floating = not c.floating end)
+
+    local min = create_title_button(c, min_color, bg_normal)
+    min:connect_signal("button::press", function() c.minimized = true end)
+
     if focused_bool then
         tab_content = wibox.widget {
             {
                 awful.widget.clienticon(c),
-                top = dpi(6),
+                top = dpi(10),
                 left = dpi(15),
-                bottom = dpi(6),
+                bottom = dpi(10),
                 widget = wibox.container.margin
             },
             text_temp,
-            nil,
+            {
+                {min, floating, close, layout = wibox.layout.fixed.horizontal},
+                top = dpi(10),
+                right = dpi(10),
+                bottom = dpi(10),
+                widget = wibox.container.margin
+            },
             expand = "none",
             layout = wibox.layout.align.horizontal
         }


### PR DESCRIPTION
I remember that in previous versions in Bling it already had buttons for the tabbars as I show in the image. This pull request is to return if possible those buttons for the tabbars of the windows.


I hope they can return them because even in the documentation for this it tells you that you can change the color of the buttons, but since these do not exist, this can be confusing (well that was my case as a novice AwesomeWM user)

![example](https://user-images.githubusercontent.com/54044230/125880592-087c8d93-daf7-4a6a-9ab7-b6b5835c534e.png)

