### PR TITLE
Fixes for the playerctl_lib signals

### DIFF
--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -98,10 +98,10 @@ local function metadata_cb(player, metadata)
         -- changed, so check to see if they have
         index = index + 1
         if (player ~= last_player or title ~= last_title or
-           artist ~= last_artist) and (artUrl ~= "" or index == 2)
+           artist ~= last_artist) and (artUrl ~= "" or index >= 2)
         then
-
             if (title == "" and artist == "" and artUrl == "") then return end
+            index = 0
             if artUrl ~= "" then
                 awful.spawn.with_line_callback(get_album_art(artUrl), {
                     stdout = function(line)
@@ -130,7 +130,6 @@ local function metadata_cb(player, metadata)
             last_artist = artist
             last_artUrl = artUrl
         end
-        if index == 2 then index = 0 end
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -98,15 +98,21 @@ local function metadata_cb(player, metadata)
         if player ~= last_player or title ~= last_title or
            artist ~= last_artist or artUrl ~= last_artUrl
         then
-            awful.spawn.with_line_callback(get_album_art(artUrl), {
-                stdout = function(line)
-                    awesome.emit_signal("bling::playerctl::title_artist_album",
-                                        title,
-                                        artist,
-                                        line,
-                                        player.player_name)
-                end
-            })
+            if artUrl ~= "" then
+                awful.spawn.with_line_callback(get_album_art(artUrl), {
+                    stdout = function(line)
+                        awesome.emit_signal("bling::playerctl::title_artist_album",
+                                            title,
+                                            artist,
+                                            line,
+                                            player.player_name)
+                    end
+                })
+            else
+                awesome.emit_signal(
+                        "bling::playerctl::title_artist_album", title,
+                        artist, player.player_name)
+            end
             -- Re-sync with position timer when track changes
             position_timer:again()
             last_player = player

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -100,6 +100,8 @@ local function metadata_cb(player, metadata)
         if (player ~= last_player or title ~= last_title or
            artist ~= last_artist) and (artUrl ~= "" or index == 2)
         then
+
+            if (title == "" and artist == "" and artUrl == "") then return end
             if artUrl ~= "" then
                 awful.spawn.with_line_callback(get_album_art(artUrl), {
                     stdout = function(line)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -59,6 +59,10 @@ fi
 
 tmp_cover_path="${tmp_dir}cover.png"
 
+if [ -f ${tmp_dir}cover.png ]; then
+    rm ${tmp_dir}cover.png
+fi
+
 if [ ! -d "$tmp_dir" ]; then
     mkdir -p $tmp_dir
 fi

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -59,10 +59,6 @@ fi
 
 tmp_cover_path="${tmp_dir}cover.png"
 
-if [ -f ${tmp_dir}cover.png ]; then
-    rm ${tmp_dir}cover.png
-fi
-
 if [ ! -d "$tmp_dir" ]; then
     mkdir -p $tmp_dir
 fi

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -100,15 +100,27 @@ local function metadata_cb(player, metadata)
         if (player ~= last_player or title ~= last_title or
            artist ~= last_artist) and (artUrl ~= "" or index == 2)
         then
-            awful.spawn.with_line_callback(get_album_art(artUrl), {
-                stdout = function(line)
-                    awesome.emit_signal("bling::playerctl::title_artist_album",
-                                        title,
-                                        artist,
-                                        line,
-                                        player.player_name)
-                end
-            })
+            if artUrl ~= "" then
+                awful.spawn.with_line_callback(get_album_art(artUrl), {
+                    stdout = function(line)
+                        awesome.emit_signal(
+                            "bling::playerctl::title_artist_album",
+                            title,
+                            artist,
+                            line,
+                            player.player_name
+                        )
+                    end
+                })
+            else
+                awesome.emit_signal(
+                    "bling::playerctl::title_artist_album",
+                    title,
+                    artist,
+                    "",
+                    player.player_name
+                )
+            end
             -- Re-sync with position timer when track changes
             position_timer:again()
             last_player = player

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -100,21 +100,15 @@ local function metadata_cb(player, metadata)
         if (player ~= last_player or title ~= last_title or
            artist ~= last_artist) and (artUrl ~= "" or index == 2)
         then
-            if artUrl ~= "" then
-                awful.spawn.with_line_callback(get_album_art(artUrl), {
-                    stdout = function(line)
-                        awesome.emit_signal("bling::playerctl::title_artist_album",
-                                            title,
-                                            artist,
-                                            line,
-                                            player.player_name)
-                    end
-                })
-            else
-                awesome.emit_signal(
-                        "bling::playerctl::title_artist_album", title,
-                        artist, player.player_name)
-            end
+            awful.spawn.with_line_callback(get_album_art(artUrl), {
+                stdout = function(line)
+                    awesome.emit_signal("bling::playerctl::title_artist_album",
+                                        title,
+                                        artist,
+                                        line,
+                                        player.player_name)
+                end
+            })
             -- Re-sync with position timer when track changes
             position_timer:again()
             last_player = player

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -74,6 +74,7 @@ local last_player = nil
 local last_title = ""
 local last_artist = ""
 local last_artUrl = ""
+local index = 0
 local function metadata_cb(player, metadata)
     if update_on_activity then
         manager:move_player_to_top(player)
@@ -95,8 +96,9 @@ local function metadata_cb(player, metadata)
     if player == manager.players[1] then
         -- Callback can be called even though values we care about haven't
         -- changed, so check to see if they have
-        if player ~= last_player or title ~= last_title or
-           artist ~= last_artist or artUrl ~= last_artUrl
+        index = index + 1
+        if (player ~= last_player or title ~= last_title or
+           artist ~= last_artist) and (artUrl ~= "" or index == 2)
         then
             if artUrl ~= "" then
                 awful.spawn.with_line_callback(get_album_art(artUrl), {
@@ -120,6 +122,7 @@ local function metadata_cb(player, metadata)
             last_artist = artist
             last_artUrl = artUrl
         end
+        if index == 2 then index = 0 end
     end
 end
 


### PR DESCRIPTION
* Only pass artUrl to the signal if it's not empty
* Fix for double signals:

What I've found while using dbus-monitor is that playerctl sends a bunch of messages whenever media is changed, with the first one always having the artUrl empty.
If the media does have an artUrl, the second and next messages will contain the artUrl resulting in artUrl ~= last_artUrl becoming true and triggering another signal
The hacky method in the commit will only trigger a new signal if artUrl is not empty, or on the second message sent (as some media don't provide any art)