### PR TITLE
Tab pick by direction

### DIFF
--- a/docs/module/tabbed.md
+++ b/docs/module/tabbed.md
@@ -10,6 +10,7 @@ bling.module.tabbed.pick()            -- picks a client with your cursor to add 
 bling.module.tabbed.pop()             -- removes the focused client from the tabbing group
 bling.module.tabbed.iter()            -- iterates through the currently focused tabbing group
 bling.module.tabbed.pick_with_dmenu() -- picks a client with a dmenu application (defaults to rofi, other options can be set with a string parameter like "dmenu")
+bling.module.tabbed.pick_by_direction(dir) -- picks a client based on direction ("up", "down", "left" or "right")
 ```
 
 ### Theme Variables

--- a/helpers/client.lua
+++ b/helpers/client.lua
@@ -67,6 +67,7 @@ end
 --- Finds all clients that satisfy the passed rule
 --
 -- @param rule The rule to be searched for
+-- @retrun A list of clients that match the given rule
 function _client.find(rule)
     local function matcher(c) return awful.rules.match(c, rule) end
     local clients = client.get()
@@ -80,5 +81,23 @@ function _client.find(rule)
 
     return matches
 end
+
+
+--- Gets the next client by direction from the focused one
+-- 
+-- @param direction it the direction as a string ("up", "down", "left" or "right")
+-- @retrun the client in the given direction starting at the currently focused one, nil otherwise
+function _client.get_by_direction(direction)
+    local sel = client.focus
+    if not sel then return nil end
+    local cltbl = sel.screen:get_clients()
+    local geomtbl = {}
+    for i, cl in ipairs(cltbl) do
+        geomtbl[i] = cl:geometry()
+    end
+    local target = gears.geometry.rectangle.get_in_direction(direction, geomtbl, sel:geometry())
+    return cltbl[target]
+end
+
 
 return _client

--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -93,7 +93,8 @@ end
 -- select a client by direction and make it tab in the currently focused tab
 tabbed.pick_by_direction = function(direction) 
     local sel = client.focus
-    if not sel or not sel.bling_tabbed then return end
+    if not sel then return end
+    if not sel.bling_tabbed then tabbed.init(sel) end
     local c = helpers.client.get_by_direction(direction)
     if not c then return end
     tabbed.add(c, sel.bling_tabbed)

--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -90,6 +90,15 @@ tabbed.pick = function()
     end)
 end
 
+-- select a client by direction and make it tab in the currently focused tab
+tabbed.pick_by_direction = function(direction) 
+    local sel = client.focus
+    if not sel or not sel.bling_tabbed then return end
+    local c = helpers.client.get_by_direction(direction)
+    if not c then return end
+    tabbed.add(c, sel.bling_tabbed)
+end
+
 -- use dmenu to select a client and make it tab in the currently focused tab 
 tabbed.pick_with_dmenu = function(dmenu_command)
     if not client.focus then return end


### PR DESCRIPTION
Instead of picking the next tabbed client with the cursor or with dmenu, one should now be able to pick it through directions. ie `bling.module.tabbed.pick_by_direction("left")` should merge with the client to the left of the currently focused one. Someone please test it before I merge.

- [x] the thing
- [x] the docs