### PR TITLE
Tabbed: added a signal and a way to disable the titlebar

### DIFF
--- a/docs/module/tabbed.md
+++ b/docs/module/tabbed.md
@@ -29,6 +29,7 @@ theme.tabbar_bg_normal = "#000000"          -- background color of the focused c
 theme.tabbar_fg_normal = "#ffffff"          -- foreground color of the focused client on the tabbar
 theme.tabbar_bg_focus  = "#1A2026"          -- background color of unfocused clients on the tabbar
 theme.tabbar_fg_focus  = "#ff0000"          -- foreground color of unfocused clients on the tabbar
+theme.tabbar_disable = false                -- disable the tab bar entirely
 
 -- the following variables are currently only for the "modern" tabbar style
 theme.tabbar_color_close = "#f9929b"        -- chnges the color of the close button
@@ -43,3 +44,10 @@ Modern theme:
 <img src="https://imgur.com/omowmIQ.png" width="600"/>
 
 *screenshot by [javacafe](https://github.com/JavaCafe01)*
+
+### Signals
+The tabbed module emits 1 signals for the purpose of integrating with your rice,
+```lua
+-- bling::tabbed::update -- triggered whenever a tabbed object is updated
+--                tabobj -- the object that caused the update
+```

--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -38,9 +38,9 @@ tabbed.remove = function(c)
     local tabobj = c.bling_tabbed
     table.remove(tabobj.clients, tabobj.focused_idx)
     if not beautiful.tabbar_disable then
-		awful.titlebar.hide(c, bar.position)
-	end
-	c.bling_tabbed = nil
+        awful.titlebar.hide(c, bar.position)
+    end
+    c.bling_tabbed = nil
     tabbed.switch_to(tabobj, 1)
 end
 
@@ -62,7 +62,7 @@ tabbed.add = function(c, tabobj)
     -- but the new client needs to have the tabobj property 
     -- before a clean switch can happen
     tabbed.update(tabobj)
-	awesome.emit_signal("bling::tabbed::client_added", tabobj)
+    awesome.emit_signal("bling::tabbed::client_added", tabobj)
     tabbed.switch_to(tabobj, #tabobj.clients)
 end
 
@@ -141,10 +141,10 @@ tabbed.update = function(tabobj)
         end
     end
 
-	awesome.emit_signal("bling::tabbed::update", tabobj)
+    awesome.emit_signal("bling::tabbed::update", tabobj)
     if not beautiful.tabbar_disable then 
-		tabbed.update_tabbar(tabobj)
-	end
+        tabbed.update_tabbar(tabobj)
+    end
 end
 
 -- change focused tab by absolute index

--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -37,8 +37,10 @@ tabbed.remove = function(c)
     if not c or not c.bling_tabbed then return end
     local tabobj = c.bling_tabbed
     table.remove(tabobj.clients, tabobj.focused_idx)
-    awful.titlebar.hide(c, bar.position)
-    c.bling_tabbed = nil
+    if not beautiful.tabbar_disable then
+		awful.titlebar.hide(c, bar.position)
+	end
+	c.bling_tabbed = nil
     tabbed.switch_to(tabobj, 1)
 end
 
@@ -60,6 +62,7 @@ tabbed.add = function(c, tabobj)
     -- but the new client needs to have the tabobj property 
     -- before a clean switch can happen
     tabbed.update(tabobj)
+	awesome.emit_signal("bling::tabbed::client_added", tabobj)
     tabbed.switch_to(tabobj, #tabobj.clients)
 end
 
@@ -138,10 +141,13 @@ tabbed.update = function(tabobj)
         end
     end
 
-    tabbed.update_tabbar(tabobj)
+	awesome.emit_signal("bling::tabbed::update", tabobj)
+    if not beautiful.tabbar_disable then 
+		tabbed.update_tabbar(tabobj)
+	end
 end
 
--- change docused tab by absolute index
+-- change focused tab by absolute index
 tabbed.switch_to = function(tabobj, new_idx)
     local old_focused_c = tabobj.clients[tabobj.focused_idx]
     tabobj.focused_idx = new_idx


### PR DESCRIPTION
![1627386844](https://user-images.githubusercontent.com/38278035/127149274-15436f47-b032-4407-b64b-3ff4bf2e0900.png)
This allows you to much more easily integrate bling into your actual titlebar and no longer have 2 titlebars taking up space, it also allows you to represent bling tabs in your bar but that is quite a chore

Example code for titlebar
```lua
	local tabbed_icons = wibox.widget({
		layout = wibox.layout.fixed.horizontal,
		spacing = dpi(4),
	})

	awesome.connect_signal("bling::tabbed::update", function(group)
		local focused = group.clients[group.focused_idx]
		if require("misc.libs.stdlib").contains(group.clients, c) then
			tabbed_icons:reset()
			for idx, _c in ipairs(group.clients) do
				tabbed_icons:add(wibox.widget({
					{
						{
							{
								client = _c,
								widget = awful.widget.clienticon,
								forced_width = 20,
								forced_height = 20,
							},
							widget = wibox.container.margin,
							margins = dpi(4),
						},
						widget = wibox.container.background,
						bg = _c == focused and "#32302f" or "#00000000",
						shape = require("misc.libs.stdlib").rounded(5),
						buttons = awful.button({}, mouse.LEFT, function()
							bling.module.tabbed.switch_to(group, idx)
						end),
					},
					widget = wibox.container.place,
					halign = "center",
					valign = "center",
				}))
			end
		end
	end)
```
and the bar code: https://github.com/undefinedDarkness/rice/blob/master/.config/awesome/subcomponents/tasklist.lua

:sweat_smile: this might not be all that useful to most people lol