### PR TITLE
scratchpad signals

### DIFF
--- a/docs/module/scratch.md
+++ b/docs/module/scratch.md
@@ -34,7 +34,7 @@ local anim_x = awestore.tweened(1920, {
     easing = awestore.easing.cubic_in_out
 })
 
-local term_scratch = bling.module.scratchpad:new {
+local term_scratch = bling.module.scratchpad {
     command = "wezterm start --class spad",           -- How to spawn the scratchpad
     rule = { instance = "spad" },                     -- The rule that the scratchpad will be searched by
     sticky = true,                                    -- Whether the scratchpad should be sticky
@@ -54,3 +54,16 @@ term_scratch:toggle()   -- toggles the scratchpads visibility
 term_scratch:turn_on()  -- turns the scratchpads visibility on
 term_scratch:turn_off() -- turns the scratchpads visibility off
 ```
+
+You can also connect to signals as you are used to for further customization. For example like that:
+
+```lua
+term_scratch:connect_signal("turn_on", function(c) naughty.notify({title = tostring(c.name)}) end)
+```
+
+The following signals are currently available. Each of them passes the client on which it operated as an argument:
+
+- `turn_on` fires when the scratchpad is turned on on a tag that it wasn't present on before
+- `turn_off` fires when the scratchpad is turned off on a tag
+- `launch` fires when the scratchpad is launched with the given command and when it found the correponding client with the given rule
+

--- a/docs/module/scratch.md
+++ b/docs/module/scratch.md
@@ -58,12 +58,13 @@ term_scratch:turn_off() -- turns the scratchpads visibility off
 You can also connect to signals as you are used to for further customization. For example like that:
 
 ```lua
-term_scratch:connect_signal("turn_on", function(c) naughty.notify({title = tostring(c.name)}) end)
+term_scratch:connect_signal("turn_on", function(c) naughty.notify({title = "Turned on!"}) end)
 ```
 
-The following signals are currently available. Each of them passes the client on which it operated as an argument:
+The following signals are currently available. `turn_on`, `turn_off` and `inital_apply` pass the client on which they operated as an argument:
 
 - `turn_on` fires when the scratchpad is turned on on a tag that it wasn't present on before
 - `turn_off` fires when the scratchpad is turned off on a tag
-- `launch` fires when the scratchpad is launched with the given command and when it found the correponding client with the given rule
+- `spawn` fires when the scratchpad is launched with the given command
+- `inital_apply` fires after `spawn`, when a corresponding client has been found and the properties have been applied
 

--- a/module/scratchpad.lua
+++ b/module/scratchpad.lua
@@ -38,9 +38,9 @@ function Scratchpad:apply(c)
         height = self.geometry.height
     })
     if self.autoclose then
-        c:connect_signal("unfocus", function(c)
-            c.sticky = false -- client won't turn off if sticky
-            helpers.client.turn_off(c)
+        c:connect_signal("unfocus", function(c1)
+            c1.sticky = false -- client won't turn off if sticky
+            helpers.client.turn_off(c1)
         end)
     end
 end
@@ -81,6 +81,7 @@ function Scratchpad:turn_on()
         end
 
         helpers.client.turn_on(c)
+        self:emit_signal("turn_on", c)
 
         -- Unsubscribe
         if anim_x then
@@ -101,22 +102,21 @@ function Scratchpad:turn_on()
                     unsub_y()
                 end)
         end
-        self:emit_signal("turn_on", c)
         return
     end
     if not c then
         -- if no client was found, spawn one, find the corresponding window,
         --  apply the properties only once (until the next closing)
         local pid = awful.spawn.with_shell(self.command)
-        local function inital_apply(c)
-            if helpers.client.is_child_of(c, pid) then
-                self:apply(c)
-                self:emit_signal("launch", c)
-            end
+        self:emit_signal("spawn")
+        local function inital_apply(c1)
+            if helpers.client.is_child_of(c1, pid) then
+                self:apply(c1)
+                self:emit_signal("inital_apply", c1)
             client.disconnect_signal("manage", inital_apply)
+            end
         end
         client.connect_signal("manage", inital_apply)
-        -- self:emit_signal("launch", nil)
         return
     end
 end
@@ -154,6 +154,7 @@ function Scratchpad:turn_off()
                         function()
                     self.in_anim = false
                     helpers.client.turn_off(c)
+                    self:emit_signal("turn_off", c)
                     unsub()
                 end)
         end
@@ -165,12 +166,15 @@ function Scratchpad:turn_off()
                         function()
                     self.in_anim = false
                     helpers.client.turn_off(c)
+                    self:emit_signal("turn_off", c)
                     unsub()
                 end)
         end
 
-        if not anim_x and not anim_y then helpers.client.turn_off(c) end
-        self:emit_signal("turn_off", c)
+        if not anim_x and not anim_y then
+            helpers.client.turn_off(c)
+            self:emit_signal("turn_off", c)
+        end
     end
 end
 


### PR DESCRIPTION
This PR will add awesome-style signals to scratchpad instances. Currently there are three: `turn_on`, `turn_off` and `launch`. I'm not completly set on the names of the signals and whether or not to pass them arguments. Also `turn_on` currently misfires when the scratchpad gains focus through the `turn_on` function. 
- [ ] docs, example usage
- [ ] fix `turn_on` misfire
