### PR TITLE
Fix an error with playerctl

### DIFF
--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -36,7 +36,7 @@ local function position_cb()
     local player = manager.players[1]
     if player then
         local position = player:get_position() / 1000000
-        local length = player.metadata.value["mpris:length"] / 1000000
+        local length = (player.metadata.value["mpris:length"] or 0) / 1000000
         if position ~= last_position or length ~= last_length then
             awesome.emit_signal("bling::playerctl::position",
                                 position,


### PR DESCRIPTION
I encountered some errors when player wasn't nil (i.e firefox was running but no media was playing) so this fixes that
