### PR TITLE
Add playerctl lib signals debounce as a better workaround for #77

### DIFF
--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -120,7 +120,7 @@ local function metadata_cb(player, metadata)
                                     title,
                                     artist,
                                     line,
-                                    player_name
+                                    player.player_name
                                 )
                             end
                         })
@@ -130,7 +130,7 @@ local function metadata_cb(player, metadata)
                             title,
                             artist,
                             "",
-                            player_name
+                            player.player_name
                         )
                     end
                 end


### PR DESCRIPTION
I started having issues again (I think it's a result of 74f522cc8823eaffa4e11b6635951f9e196462e3) with YouTube and playerctl notifications, so this should re-fix it and in a less hacky way by implementing the suggestion @HumblePresent made at #77.

The 0.3 delay seems to do the job to stop double notifications (less is a hit-and-miss), but more testing is needed

A side effect I found is that when switching songs fast enough, a signal will be emitted only for the last song.  I personally think it's a good change, as I'd rather not have 10 different notifications when I'm only trying to skip some songs
