### PR TITLE
Playerctl refactor

### DIFF
--- a/docs/signals/pctl.md
+++ b/docs/signals/pctl.md
@@ -104,8 +104,8 @@ By default, this module will output signals from the most recently active player
 | Option              | playerctl_cli      | playerctl_lib      |
 | ------------------- | ------------------ | ------------------ |
 | backend             | :heavy_check_mark: | :heavy_check_mark: |
-| ignore              |                    | :heavy_check_mark: |
-| player              |                    | :heavy_check_mark: |
+| ignore              | :heavy_check_mark: | :heavy_check_mark: |
+| player              | :heavy_check_mark: | :heavy_check_mark: |
 | update_on_activity  |                    | :heavy_check_mark: |
 | interval            | :heavy_check_mark: | :heavy_check_mark: |
 

--- a/signal/playerctl/init.lua
+++ b/signal/playerctl/init.lua
@@ -1,19 +1,5 @@
-local beautiful = require("beautiful")
-
--- Use CLI backend as default as it is supported on most if not all systems
-local backend_config = beautiful.playerctl_backend or "playerctl_cli"
-local backends = {
-    playerctl_cli = require(... .. ".playerctl_cli"),
-    playerctl_lib = require(... .. ".playerctl_lib")
+return
+{
+    cli = require(... .. ".playerctl_cli"),
+    lib = require(... .. ".playerctl_lib")
 }
-
-local function enable_wrapper(args)
-    backend_config = (args and args.backend) or backend_config
-    backends[backend_config].enable(args)
-end
-
-local function disable_wrapper()
-    backends[backend_config].disable()
-end
-
-return {enable = enable_wrapper, disable = disable_wrapper}

--- a/signal/playerctl/init.lua
+++ b/signal/playerctl/init.lua
@@ -1,5 +1,19 @@
-return
-{
-    cli = require(... .. ".playerctl_cli"),
-    lib = require(... .. ".playerctl_lib")
+local beautiful = require("beautiful")
+
+-- Use CLI backend as default as it is supported on most if not all systems
+local backend_config = beautiful.playerctl_backend or "playerctl_cli"
+local backends = {
+    playerctl_cli = require(... .. ".playerctl_cli"),
+    playerctl_lib = require(... .. ".playerctl_lib"),
 }
+
+local function enable_wrapper(args)
+    backend_config = (args and args.backend) or backend_config
+    backends[backend_config].enable(args)
+end
+
+local function disable_wrapper()
+    backends[backend_config].disable()
+end
+
+return { enable = enable_wrapper, disable = disable_wrapper }

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -168,15 +168,19 @@ local function emit_player_shuffle(self)
 end
 
 local function parse_args(self, args)
-    if type(args.player) == "string" then
-        self._private.cmd = self._private.cmd .. args.player .. " "
-    elseif type(args.player) == "table" then
-        for index, player in pairs(args.player) do
-            self._private.cmd = self._private.cmd .. player
-            if index < #args.player then
-                self._private.cmd = self._private.cmd .. ","
-            else
-                self._private.cmd = self._private.cmd .. " "
+    if args.player then
+        self._private.cmd = self._private.cmd .. "--player="
+
+        if type(args.player) == "string" then
+            self._private.cmd = self._private.cmd .. args.player .. " "
+        elseif type(args.player) == "table" then
+            for index, player in pairs(args.player) do
+                self._private.cmd = self._private.cmd .. player
+                if index < #args.player then
+                    self._private.cmd = self._private.cmd .. ","
+                else
+                    self._private.cmd = self._private.cmd .. " "
+                end
             end
         end
     end
@@ -193,7 +197,7 @@ local function new(args)
 
     ret._private = {}
     ret._private.metadata_timer = nil
-    ret._private.cmd = "playerctl --player="
+    ret._private.cmd = "playerctl "
     parse_args(ret, args)
 
     emit_player_metadata(ret)

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -133,13 +133,11 @@ local function emit_player_metadata(self)
 
                             awful.spawn.with_line_callback(get_art_script, {
                                 stdout = function(stdout)
-                                    self:emit_signal("metadata", title, artist,
-                                                    stdout, album, player_name)
+                                    self:emit_signal("metadata", title, artist, stdout, album, player_name)
                                 end
                             })
                         else
-                            self:emit_signal("metadata", title, artist, "",
-                                            album, player_name)
+                            self:emit_signal("metadata", title, artist, "", album, player_name)
                         end
                     else
                         self:emit_signal("no_players")

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -37,10 +37,7 @@ local playerctl = { mt = {} }
 function playerctl:disable()
     self._private.metadata_timer:stop()
     self._private.metadata_timer = nil
-    awful.spawn.with_shell("pkill --full --uid " .. os.getenv("USER") ..
-                               " '^playerctl status -F'")
-    awful.spawn.with_shell("pkill --full --uid " .. os.getenv("USER") ..
-                               " '^playerctl metadata --format'")
+    awful.spawn.with_shell("killall playerctl")
 end
 
 function playerctl:pause()

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -89,11 +89,7 @@ function playerctl:set_shuffle(shuffle)
 end
 
 function playerctl:cycle_shuffle()
-    if self._private.shuffle == false then
-        self:set_shuffle(true)
-    elseif self._private.shuffle == true then
-        self:set_shuffle(false)
-    end
+    self:set_shuffle(not self._private.shuffle)
 end
 
 function playerctl:set_volume(volume)

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -83,11 +83,7 @@ function playerctl:set_position(position)
 end
 
 function playerctl:set_shuffle(shuffle)
-    if shuffle == true then
-        shuffle = "on"
-    else
-        shuffle = "off"
-    end
+    shuffle = shuffle and "on" or "off"
 
     awful.spawn.with_shell(self._private.cmd .. "shuffle " .. shuffle)
 end

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -184,6 +184,23 @@ local function parse_args(self, args)
             end
         end
     end
+
+    if args.ignore then
+        self._private.cmd = self._private.cmd .. "--ignore-player="
+
+        if type(args.ignore) == "string" then
+            self._private.cmd = self._private.cmd .. args.ignore .. " "
+        elseif type(args.ignore) == "table" then
+            for index, player in pairs(args.ignore) do
+                self._private.cmd = self._private.cmd .. player
+                if index < #args.ignore then
+                    self._private.cmd = self._private.cmd .. ","
+                else
+                    self._private.cmd = self._private.cmd .. " "
+                end
+            end
+        end
+    end
 end
 
 local function new(args)

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -29,7 +29,7 @@ local gstring = require("gears.string")
 local beautiful = require("beautiful")
 local setmetatable = setmetatable
 local tonumber = tonumber
-local pairs = pairs
+local ipairs = ipairs
 local type = type
 
 local playerctl = { mt = {} }
@@ -228,7 +228,7 @@ local function parse_args(self, args)
         if type(args.player) == "string" then
             self._private.cmd = self._private.cmd .. args.player .. " "
         elseif type(args.player) == "table" then
-            for index, player in pairs(args.player) do
+            for index, player in ipairs(args.player) do
                 self._private.cmd = self._private.cmd .. player
                 if index < #args.player then
                     self._private.cmd = self._private.cmd .. ","
@@ -245,7 +245,7 @@ local function parse_args(self, args)
         if type(args.ignore) == "string" then
             self._private.cmd = self._private.cmd .. args.ignore .. " "
         elseif type(args.ignore) == "table" then
-            for index, player in pairs(args.ignore) do
+            for index, player in ipairs(args.ignore) do
                 self._private.cmd = self._private.cmd .. player
                 if index < #args.ignore then
                     self._private.cmd = self._private.cmd .. ","

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -112,7 +112,7 @@ local function emit_player_metadata(self)
                 art_url = art_url:gsub("open.spotify.com", "i.scdn.co")
             end
 
-            if self._private.metadata_timer ~= nil
+            if self._private.metadata_timer
                 and self._private.metadata_timer.started
             then
                 self._private.metadata_timer:stop()

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -45,6 +45,70 @@ function playerctl:disable()
                                " '^playerctl metadata --format'")
 end
 
+function playerctl:pause()
+    awful.spawn.with_shell(self._private.cmd .. "pause")
+end
+
+function playerctl:play()
+    awful.spawn.with_shell(self._private.cmd .. "play")
+end
+
+function playerctl:stop()
+    awful.spawn.with_shell(self._private.cmd .. "stop")
+end
+
+function playerctl:play_pause()
+    awful.spawn.with_shell(self._private.cmd .. "play-pause")
+end
+
+function playerctl:previous()
+    awful.spawn.with_shell(self._private.cmd .. "previous")
+end
+
+function playerctl:next()
+    awful.spawn.with_shell(self._private.cmd .. "next")
+end
+
+function playerctl:set_loop_status(loop_status)
+    awful.spawn.with_shell(self._private.cmd .. "loop " .. loop_status)
+end
+
+function playerctl:cycle_loop_status()
+    if self._private.loop_status == "None" then
+        self:set_loop_status("Track")
+    elseif self._private.loop_status == "Track" then
+        self:set_loop_status("Playlist")
+    elseif self._private.loop_status == "Playlist" then
+        self:set_loop_status("None")
+    end
+end
+
+function playerctl:set_position(position)
+    awful.spawn.with_shell(self._private.cmd .. "position " .. position)
+end
+
+function playerctl:set_shuffle(shuffle)
+    if shuffle == true then
+        shuffle = "on"
+    else
+        shuffle = "off"
+    end
+
+    awful.spawn.with_shell(self._private.cmd .. "shuffle " .. shuffle)
+end
+
+function playerctl:cycle_shuffle()
+    if self._private.shuffle == false then
+        self:set_shuffle(true)
+    elseif self._private.shuffle == true then
+        self:set_shuffle(false)
+    end
+end
+
+function playerctl:set_volume(volume)
+    awful.spawn.with_shell(self._private.cmd .. "next" .. volume)
+end
+
 local function emit_player_metadata(self)
     local metadata_cmd = self._private.cmd .. "metadata --format 'title_{{title}}artist_{{artist}}art_url_{{mpris:artUrl}}player_name_{{playerName}}album_{{album}}' -F"
 
@@ -148,7 +212,8 @@ local function emit_player_loop_status(self)
 
     awful.spawn.with_line_callback(loop_status_cmd, {
         stdout = function(line)
-            self:emit_signal("loop_status", line)
+            self._private.loop_status = line
+            self:emit_signal("loop_status", line:lower())
         end,
     })
 end
@@ -159,8 +224,10 @@ local function emit_player_shuffle(self)
     awful.spawn.with_line_callback(shuffle_cmd, {
         stdout = function(line)
             if line:find("On") then
+                self._private.shuffle = true
                 self:emit_signal("shuffle", true)
             else
+                self._private.shuffle = false
                 self:emit_signal("shuffle", false)
             end
         end,

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -5,8 +5,8 @@
 --      title (string)
 --      artist  (string)
 --      album_path (string)
---      player_name (string)
 --      album (string)
+--      player_name (string)
 -- position
 --      interval_sec (number)
 --      length_sec (number)
@@ -134,12 +134,12 @@ local function emit_player_metadata(self)
                             awful.spawn.with_line_callback(get_art_script, {
                                 stdout = function(stdout)
                                     self:emit_signal("metadata", title, artist,
-                                                    stdout, player_name, album)
+                                                    stdout, album, player_name)
                                 end
                             })
                         else
                             self:emit_signal("metadata", title, artist, "",
-                                                        player_name, album)
+                                            album, player_name)
                         end
                     else
                         self:emit_signal("no_players")

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -33,10 +33,8 @@ local pairs = pairs
 local type = type
 
 local playerctl = { mt = {} }
-local instance = nil
 
 function playerctl:disable()
-    instance = nil
     self._private.metadata_timer:stop()
     self._private.metadata_timer = nil
     awful.spawn.with_shell("pkill --full --uid " .. os.getenv("USER") ..
@@ -295,10 +293,7 @@ local function new(args)
 end
 
 function playerctl.mt:__call(...)
-    if not instance then
-        instance = new(...)
-    end
-    return instance
+    return new(...)
 end
 
 -- On startup instead of on playerctl object init to make it

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -40,60 +40,117 @@ function playerctl:disable()
     awful.spawn.with_shell("killall playerctl")
 end
 
-function playerctl:pause()
-    awful.spawn.with_shell(self._private.cmd .. "pause")
-end
-
-function playerctl:play()
-    awful.spawn.with_shell(self._private.cmd .. "play")
-end
-
-function playerctl:stop()
-    awful.spawn.with_shell(self._private.cmd .. "stop")
-end
-
-function playerctl:play_pause()
-    awful.spawn.with_shell(self._private.cmd .. "play-pause")
-end
-
-function playerctl:previous()
-    awful.spawn.with_shell(self._private.cmd .. "previous")
-end
-
-function playerctl:next()
-    awful.spawn.with_shell(self._private.cmd .. "next")
-end
-
-function playerctl:set_loop_status(loop_status)
-    awful.spawn.with_shell(self._private.cmd .. "loop " .. loop_status)
-end
-
-function playerctl:cycle_loop_status()
-    if self._private.loop_status == "None" then
-        self:set_loop_status("Track")
-    elseif self._private.loop_status == "Track" then
-        self:set_loop_status("Playlist")
-    elseif self._private.loop_status == "Playlist" then
-        self:set_loop_status("None")
+function playerctl:pause(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " pause")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "pause")
     end
 end
 
-function playerctl:set_position(position)
-    awful.spawn.with_shell(self._private.cmd .. "position " .. position)
+function playerctl:play(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " play")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "play")
+    end
 end
 
-function playerctl:set_shuffle(shuffle)
+function playerctl:stop(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " stop")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "stop")
+    end
+end
+
+function playerctl:play_pause(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " play-pause")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "play-pause")
+    end
+end
+
+function playerctl:previous(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " previous")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "previous")
+    end
+end
+
+function playerctl:next(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " next")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "next")
+    end
+end
+
+function playerctl:set_loop_status(player, loop_status)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " loop " .. loop_status)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "loop " .. loop_status)
+    end
+end
+
+function playerctl:cycle_loop_status(player)
+    local function set_loop_status(loop_status)
+        if loop_status == "None" then
+            self:set_loop_status("Track")
+        elseif loop_status == "Track" then
+            self:set_loop_status("Playlist")
+        elseif loop_status == "Playlist" then
+            self:set_loop_status("None")
+        end
+    end
+
+    if player ~= nil then
+        awful.spawn.easy_async_with_shell("playerctl --player=" .. player .. " loop", function(stdout)
+            set_loop_status(stdout)
+        end)
+    else
+        set_loop_status(self._private.loop_status)
+    end
+end
+
+function playerctl:set_position(player, position)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " position " .. position)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "position " .. position)
+    end
+end
+
+function playerctl:set_shuffle(player, shuffle)
     shuffle = shuffle and "on" or "off"
 
-    awful.spawn.with_shell(self._private.cmd .. "shuffle " .. shuffle)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " shuffle " .. shuffle)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "shuffle " .. shuffle)
+    end
 end
 
-function playerctl:cycle_shuffle()
-    self:set_shuffle(not self._private.shuffle)
+function playerctl:cycle_shuffle(player)
+    if player ~= nil then
+        awful.spawn.easy_async_with_shell("playerctl --player=" .. player .. " shuffle", function(stdout)
+            local shuffle = stdout == "on" and true or false
+            self:set_shuffle(not self._private.shuffle)
+        end)
+    else
+        self:set_shuffle(not self._private.shuffle)
+    end
 end
 
-function playerctl:set_volume(volume)
-    awful.spawn.with_shell(self._private.cmd .. "volume " .. volume)
+function playerctl:set_volume(player, volume)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " volume " .. volume)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "volume " .. volume)
+    end
 end
 
 local function emit_player_metadata(self)

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -1,347 +1,151 @@
--- Playerctl signals
 --
 -- Provides:
--- metadata
+-- bling::playerctl::status
+--      playing (boolean)
+-- bling::playerctl::title_artist_album
 --      title (string)
---      artist  (string)
+--      artist    (string)
 --      album_path (string)
---      album (string)
---      player_name (string)
--- position
+-- bling::playerctl::position
 --      interval_sec (number)
 --      length_sec (number)
--- playback_status
---      playing (boolean)
--- volume
---      volume (number)
--- loop_status
---      loop_status (string)
--- shuffle
---      shuffle (bool)
--- no_players
---      (No parameters)
-
+-- bling::playerctl::no_players
+--
 local awful = require("awful")
-local gobject = require("gears.object")
-local gtable = require("gears.table")
-local gtimer = require("gears.timer")
-local gstring = require("gears.string")
 local beautiful = require("beautiful")
-local setmetatable = setmetatable
-local tonumber = tonumber
-local ipairs = ipairs
-local type = type
 
-local playerctl = { mt = {} }
+local interval = beautiful.playerctl_position_update_interval or 1
 
-function playerctl:disable()
-    self._private.metadata_timer:stop()
-    self._private.metadata_timer = nil
-    awful.spawn.with_shell("killall playerctl")
-end
+local function emit_player_status()
+    local status_cmd = "playerctl status -F"
 
-function playerctl:pause(player)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " pause")
-    else
-        awful.spawn.with_shell(self._private.cmd .. "pause")
-    end
-end
-
-function playerctl:play(player)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " play")
-    else
-        awful.spawn.with_shell(self._private.cmd .. "play")
-    end
-end
-
-function playerctl:stop(player)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " stop")
-    else
-        awful.spawn.with_shell(self._private.cmd .. "stop")
-    end
-end
-
-function playerctl:play_pause(player)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " play-pause")
-    else
-        awful.spawn.with_shell(self._private.cmd .. "play-pause")
-    end
-end
-
-function playerctl:previous(player)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " previous")
-    else
-        awful.spawn.with_shell(self._private.cmd .. "previous")
-    end
-end
-
-function playerctl:next(player)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " next")
-    else
-        awful.spawn.with_shell(self._private.cmd .. "next")
-    end
-end
-
-function playerctl:set_loop_status(player, loop_status)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " loop " .. loop_status)
-    else
-        awful.spawn.with_shell(self._private.cmd .. "loop " .. loop_status)
-    end
-end
-
-function playerctl:cycle_loop_status(player)
-    local function set_loop_status(loop_status)
-        if loop_status == "None" then
-            self:set_loop_status("Track")
-        elseif loop_status == "Track" then
-            self:set_loop_status("Playlist")
-        elseif loop_status == "Playlist" then
-            self:set_loop_status("None")
-        end
-    end
-
-    if player ~= nil then
-        awful.spawn.easy_async_with_shell("playerctl --player=" .. player .. " loop", function(stdout)
-            set_loop_status(stdout)
-        end)
-    else
-        set_loop_status(self._private.loop_status)
-    end
-end
-
-function playerctl:set_position(player, position)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " position " .. position)
-    else
-        awful.spawn.with_shell(self._private.cmd .. "position " .. position)
-    end
-end
-
-function playerctl:set_shuffle(player, shuffle)
-    shuffle = shuffle and "on" or "off"
-
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " shuffle " .. shuffle)
-    else
-        awful.spawn.with_shell(self._private.cmd .. "shuffle " .. shuffle)
-    end
-end
-
-function playerctl:cycle_shuffle(player)
-    if player ~= nil then
-        awful.spawn.easy_async_with_shell("playerctl --player=" .. player .. " shuffle", function(stdout)
-            local shuffle = stdout == "on" and true or false
-            self:set_shuffle(not self._private.shuffle)
-        end)
-    else
-        self:set_shuffle(not self._private.shuffle)
-    end
-end
-
-function playerctl:set_volume(player, volume)
-    if player ~= nil then
-        awful.spawn.with_shell("playerctl --player=" .. player .. " volume " .. volume)
-    else
-        awful.spawn.with_shell(self._private.cmd .. "volume " .. volume)
-    end
-end
-
-local function emit_player_metadata(self)
-    local metadata_cmd = self._private.cmd .. "metadata --format 'title_{{title}}artist_{{artist}}art_url_{{mpris:artUrl}}player_name_{{playerName}}album_{{album}}' -F"
-
-    awful.spawn.with_line_callback(metadata_cmd, {
-        stdout = function(line)
-            local title = gstring.xml_escape(line:match('title_(.*)artist_')) or ""
-            local artist = gstring.xml_escape(line:match('artist_(.*)art_url_')) or ""
-            local art_url = line:match('art_url_(.*)player_name_') or ""
-            local player_name = line:match('player_name_(.*)album_') or ""
-            local album = gstring.xml_escape(line:match('album_(.*)')) or ""
-
-            art_url = art_url:gsub('%\n', '')
-            if player_name == "spotify" then
-                art_url = art_url:gsub("open.spotify.com", "i.scdn.co")
-            end
-
-            if self._private.metadata_timer
-                and self._private.metadata_timer.started
-            then
-                self._private.metadata_timer:stop()
-            end
-
-            self._private.metadata_timer = gtimer {
-                timeout = self.debounce_delay,
-                autostart = true,
-                single_shot = true,
-                callback = function()
-                    if title and title ~= "" then
-                        if art_url ~= "" then
-                            local get_art_script = awful.util.shell .. [[ -c '
-                                tmp_cover_path=]] .. os.tmpname() .. [[.png
-                                curl -s ']] .. art_url .. [[' --output $tmp_cover_path
-                                echo "$tmp_cover_path"
-                            ']]
-
-                            awful.spawn.with_line_callback(get_art_script, {
-                                stdout = function(stdout)
-                                    self:emit_signal("metadata", title, artist, stdout, album, player_name)
-                                end
-                            })
-                        else
-                            self:emit_signal("metadata", title, artist, "", album, player_name)
-                        end
-                    else
-                        self:emit_signal("no_players")
-                    end
+    -- Follow status
+    awful.spawn.easy_async({
+        "pkill",
+        "--full",
+        "--uid",
+        os.getenv("USER"),
+        "^playerctl status",
+    }, function()
+        awful.spawn.with_line_callback(status_cmd, {
+            stdout = function(line)
+                local playing = false
+                if line:find("Playing") then
+                    playing = true
+                else
+                    playing = false
                 end
-            }
-
-            collectgarbage("collect")
-        end,
-    })
+                awesome.emit_signal("bling::playerctl::status", playing)
+            end,
+        })
+        collectgarbage("collect")
+    end)
 end
 
-local function emit_player_position(self)
-    local position_cmd = self._private.cmd .. "position"
-    local length_cmd = self._private.cmd .. "metadata mpris:length"
+local function emit_player_info()
+    local art_script = [[
+sh -c '
 
-    awful.widget.watch(position_cmd, self.interval, function(_, interval)
+tmp_dir="$XDG_CACHE_HOME/awesome/"
+
+if [ -z ${XDG_CACHE_HOME} ]; then
+    tmp_dir="$HOME/.cache/awesome/"
+fi
+
+tmp_cover_path=${tmp_dir}"cover.png"
+
+if [ ! -d $tmp_dir  ]; then
+    mkdir -p $tmp_dir
+fi
+
+link="$(playerctl metadata mpris:artUrl)"
+
+curl -s "$link" --output $tmp_cover_path
+
+echo "$tmp_cover_path"
+']]
+
+    -- Command that lists artist and title in a format to find and follow
+    local song_follow_cmd =
+        "playerctl metadata --format 'artist_{{artist}}title_{{title}}' -F"
+
+    -- Progress Cmds
+    local prog_cmd = "playerctl position"
+    local length_cmd = "playerctl metadata mpris:length"
+
+    awful.widget.watch(prog_cmd, interval, function(_, interval)
         awful.spawn.easy_async_with_shell(length_cmd, function(length)
             local length_sec = tonumber(length) -- in microseconds
             local interval_sec = tonumber(interval) -- in seconds
             if length_sec and interval_sec then
                 if interval_sec >= 0 and length_sec > 0 then
-                    self:emit_signal("position", interval_sec, length_sec / 1000000)
+                    awesome.emit_signal(
+                        "bling::playerctl::position",
+                        interval_sec,
+                        length_sec / 1000000
+                    )
                 end
             end
         end)
         collectgarbage("collect")
     end)
+
+    -- Follow title
+    awful.spawn.easy_async({
+        "pkill",
+        "--full",
+        "--uid",
+        os.getenv("USER"),
+        "^playerctl metadata",
+    }, function()
+        awful.spawn.with_line_callback(song_follow_cmd, {
+            stdout = function(line)
+                local album_path = ""
+                awful.spawn.easy_async_with_shell(art_script, function(out)
+                    -- Get album path
+                    album_path = out:gsub("%\n", "")
+                    -- Get title and artist
+                    local artist = line:match("artist_(.*)title_")
+                    local title = line:match("title_(.*)")
+                    -- If the title is nil or empty then the players stopped
+                    if title and title ~= "" then
+                        awesome.emit_signal(
+                            "bling::playerctl::title_artist_album",
+                            title,
+                            artist,
+                            album_path
+                        )
+                    else
+                        awesome.emit_signal("bling::playerctl::no_players")
+                    end
+                end)
+                collectgarbage("collect")
+            end,
+        })
+        collectgarbage("collect")
+    end)
 end
 
-local function emit_player_playback_status(self)
-    local status_cmd = self._private.cmd .. "status -F"
+-- Emit info
+-- emit_player_status()
+-- emit_player_info()
 
-    awful.spawn.with_line_callback(status_cmd, {
-        stdout = function(line)
-            if line:find("Playing") then
-                self:emit_signal("playback_status", true)
-            else
-                self:emit_signal("playback_status", false)
-            end
-        end,
-    })
+local enable = function(args)
+    interval = (args and args.interval) or interval
+    emit_player_status()
+    emit_player_info()
 end
 
-local function emit_player_volume(self)
-    local volume_cmd = self._private.cmd .. "volume -F"
+local disable = function()
+    awful.spawn.with_shell(
+        "pkill --full --uid " .. os.getenv("USER") .. " '^playerctl status -F'"
+    )
 
-    awful.spawn.with_line_callback(volume_cmd, {
-        stdout = function(line)
-            self:emit_signal("volume", tonumber(line))
-        end,
-    })
+    awful.spawn.with_shell(
+        "pkill --full --uid "
+            .. os.getenv("USER")
+            .. " '^playerctl metadata --format'"
+    )
 end
 
-local function emit_player_loop_status(self)
-    local loop_status_cmd = self._private.cmd .. "loop -F"
-
-    awful.spawn.with_line_callback(loop_status_cmd, {
-        stdout = function(line)
-            self._private.loop_status = line
-            self:emit_signal("loop_status", line:lower())
-        end,
-    })
-end
-
-local function emit_player_shuffle(self)
-    local shuffle_cmd = self._private.cmd .. "shuffle -F"
-
-    awful.spawn.with_line_callback(shuffle_cmd, {
-        stdout = function(line)
-            if line:find("On") then
-                self._private.shuffle = true
-                self:emit_signal("shuffle", true)
-            else
-                self._private.shuffle = false
-                self:emit_signal("shuffle", false)
-            end
-        end,
-    })
-end
-
-local function parse_args(self, args)
-    if args.player then
-        self._private.cmd = self._private.cmd .. "--player="
-
-        if type(args.player) == "string" then
-            self._private.cmd = self._private.cmd .. args.player .. " "
-        elseif type(args.player) == "table" then
-            for index, player in ipairs(args.player) do
-                self._private.cmd = self._private.cmd .. player
-                if index < #args.player then
-                    self._private.cmd = self._private.cmd .. ","
-                else
-                    self._private.cmd = self._private.cmd .. " "
-                end
-            end
-        end
-    end
-
-    if args.ignore then
-        self._private.cmd = self._private.cmd .. "--ignore-player="
-
-        if type(args.ignore) == "string" then
-            self._private.cmd = self._private.cmd .. args.ignore .. " "
-        elseif type(args.ignore) == "table" then
-            for index, player in ipairs(args.ignore) do
-                self._private.cmd = self._private.cmd .. player
-                if index < #args.ignore then
-                    self._private.cmd = self._private.cmd .. ","
-                else
-                    self._private.cmd = self._private.cmd .. " "
-                end
-            end
-        end
-    end
-end
-
-local function new(args)
-    args = args or {}
-
-    local ret = gobject{}
-    gtable.crush(ret, playerctl, true)
-
-    ret.interval = args.interval or beautiful.playerctl_position_update_interval or 1
-    ret.debounce_delay = args.debounce_delay or beautiful.playerctl_debounce_delay or 0.35
-
-    ret._private = {}
-    ret._private.metadata_timer = nil
-    ret._private.cmd = "playerctl "
-    parse_args(ret, args)
-
-    emit_player_metadata(ret)
-    emit_player_position(ret)
-    emit_player_playback_status(ret)
-    emit_player_volume(ret)
-    emit_player_loop_status(ret)
-    emit_player_shuffle(ret)
-
-    return ret
-end
-
-function playerctl.mt:__call(...)
-    return new(...)
-end
-
--- On startup instead of on playerctl object init to make it
--- possible to have more than one of these running
-awful.spawn.with_shell("killall playerctl")
-
-return setmetatable(playerctl, playerctl.mt)
+return { enable = enable, disable = disable }

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -101,7 +101,7 @@ function playerctl:cycle_shuffle()
 end
 
 function playerctl:set_volume(volume)
-    awful.spawn.with_shell(self._private.cmd .. "next" .. volume)
+    awful.spawn.with_shell(self._private.cmd .. "volume " .. volume)
 end
 
 local function emit_player_metadata(self)

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -28,6 +28,7 @@ local playerctl = { mt = {} }
 local instance = nil
 
 function playerctl:disable()
+    instance = nil
     self._private.metadata_timer:stop()
     self._private.metadata_timer = nil
     awful.spawn.with_shell("pkill --full --uid " .. os.getenv("USER") ..

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -217,7 +217,7 @@ local function metadata_cb(self, player, metadata)
                 autostart = true,
                 single_shot = true,
                 callback = function()
-                    emit_metadata_signal(self, title, artist, artUrl, player.player_name, album, true)
+                    emit_metadata_signal(self, title, artist, artUrl, album, true, player.player_name)
                 end
             }
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -69,50 +69,57 @@ function playerctl:disable()
     self._private.last_artUrl = ""
 end
 
-function playerctl:pause()
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:pause()
+function playerctl:pause(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:pause()
     end
 end
 
-function playerctl:play()
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:play()
+function playerctl:play(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:play()
     end
 end
 
-function playerctl:stop()
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:stop()
+function playerctl:stop(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:stop()
     end
 end
 
-function playerctl:play_pause()
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:play_pause()
+function playerctl:play_pause(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:play_pause()
     end
 end
 
-function playerctl:previous()
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:previous()
+function playerctl:previous(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:previous()
     end
 end
 
-function playerctl:next()
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:next()
+function playerctl:next(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:next()
     end
 end
 
-function playerctl:set_loop_status(loop_status)
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:set_loop_status(loop_status)
+function playerctl:set_loop_status(player, loop_status)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_loop_status(loop_status)
     end
 end
 
-function playerctl:cycle_loop_status()
-    local player = self._private.manager.players[1]
+function playerctl:cycle_loop_status(player)
+    player = player or self._private.manager.players[1]
     if player then
         if player.loop_status == "NONE" then
             player:set_loop_status("TRACK")
@@ -124,28 +131,31 @@ function playerctl:cycle_loop_status()
     end
 end
 
-function playerctl:set_position(position)
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:set_position(position * 1000000)
+function playerctl:set_position(player, position)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_position(position * 1000000)
     end
 end
 
-function playerctl:set_shuffle(shuffle)
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:set_shuffle(shuffle)
+function playerctl:set_shuffle(player, shuffle)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_shuffle(shuffle)
     end
 end
 
-function playerctl:cycle_shuffle()
-    local player = self._private.manager.players[1]
+function playerctl:cycle_shuffle(player)
+    player = player or self._private.manager.players[1]
     if player then
         player:set_shuffle(not player.shuffle)
     end
 end
 
-function playerctl:set_volume(volume)
-    if self._private.manager.players[1] then
-        self._private.manager.players[1]:set_volume(volume)
+function playerctl:set_volume(player, volume)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_volume(volume)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -180,13 +180,11 @@ local function emit_metadata_signal(self, title, artist, artUrl, player_name, al
 
         awful.spawn.with_line_callback(get_art_script, {
             stdout = function(line)
-                self:emit_signal("metadata", title, artist, line, album,
-                                new, player_name)
+                self:emit_signal("metadata", title, artist, line, album, new, player_name)
             end
         })
     else
-        self:emit_signal("metadata", title, artist, "", album,
-                        new, player_name)
+        self:emit_signal("metadata", title, artist, "", album, new, player_name)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -446,12 +446,12 @@ local function start_manager(self)
 
     -- Callback to check if all players have exited
     function self._private.manager:on_name_vanished(name)
-        if #self._private.manager.players == 0 then
-            self._private.metadata_timer:stop()
-            self._private.position_timer:stop()
+        if #_self._private.manager.players == 0 then
+            _self._private.metadata_timer:stop()
+            _self._private.position_timer:stop()
             _self:emit_signal("no_players")
         else
-            get_current_player_info(_self, self._private.manager.players[1])
+            get_current_player_info(_self, _self._private.manager.players[1])
         end
     end
 end

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -451,7 +451,7 @@ local function start_manager(self)
     end
 
     function self._private.manager:on_player_vanished(player)
-        if self.players == 0 then
+        if #self.players == 0 then
             _self._private.metadata_timer:stop()
             _self._private.position_timer:stop()
             _self:emit_signal("no_players")

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -1,212 +1,88 @@
 -- Playerctl signals
 --
 -- Provides:
--- metadata
+-- bling::playerctl::status
+--      playing (boolean)
+--      player_name (string)
+-- bling::playerctl::title_artist_album
 --      title (string)
 --      artist  (string)
 --      album_path (string)
---      album (string)
---      new (bool)
 --      player_name (string)
--- position
+-- bling::playerctl::position
 --      interval_sec (number)
 --      length_sec (number)
 --      player_name (string)
--- playback_status
---      playing (boolean)
---      player_name (string)
--- seeked
---      position (number)
---      player_name (string)
--- volume
---      volume (number)
---      player_name (string)
--- loop_status
---      loop_status (string)
---      player_name (string)
--- shuffle
---      shuffle (boolean)
---      player_name (string)
--- exit
---      player_name (string)
--- no_players
+-- bling::playerctl::no_players
 --      (No parameters)
 
+local gears = require("gears")
 local awful = require("awful")
-local gobject = require("gears.object")
-local gtable = require("gears.table")
-local gtimer = require("gears.timer")
-local gstring = require("gears.string")
 local beautiful = require("beautiful")
-local setmetatable = setmetatable
-local ipairs = ipairs
-local pairs = pairs
-local type = type
+local Playerctl = nil
 
-local playerctl = { mt = {} }
+local manager = nil
+local metadata_timer = nil
+local position_timer = nil
 
-function playerctl:disable()
-    -- Restore default settings
-    self.ignore = {}
-    self.priority = {}
-    self.update_on_activity = true
-    self.interval = 1
-    self.debounce_delay = 0.35
+local ignore = {}
+local priority = {}
+local update_on_activity = true
+local interval = 1
 
-    -- Reset timers
-    self._private.manager = nil
-    self._private.metadata_timer:stop()
-    self._private.metadata_timer = nil
-    self._private.position_timer:stop()
-    self._private.position_timer = nil
-
-    -- Reset default values
-    self._private.last_position = -1
-    self._private.last_length = -1
-    self._private.last_player = nil
-    self._private.last_title = ""
-    self._private.last_artist = ""
-    self._private.last_artUrl = ""
-end
-
-function playerctl:pause(player)
-    player = player or self._private.manager.players[1]
+-- Track position callback
+local last_position = -1
+local last_length = -1
+local function position_cb()
+    local player = manager.players[1]
     if player then
-        player:pause()
-    end
-end
-
-function playerctl:play(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:play()
-    end
-end
-
-function playerctl:stop(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:stop()
-    end
-end
-
-function playerctl:play_pause(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:play_pause()
-    end
-end
-
-function playerctl:previous(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:previous()
-    end
-end
-
-function playerctl:next(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:next()
-    end
-end
-
-function playerctl:set_loop_status(player, loop_status)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:set_loop_status(loop_status)
-    end
-end
-
-function playerctl:cycle_loop_status(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        if player.loop_status == "NONE" then
-            player:set_loop_status("TRACK")
-        elseif player.loop_status == "TRACK" then
-            player:set_loop_status("PLAYLIST")
-        elseif player.loop_status == "PLAYLIST" then
-            player:set_loop_status("NONE")
+        local position = player:get_position() / 1000000
+        local length = (player.metadata.value["mpris:length"] or 0) / 1000000
+        if position ~= last_position or length ~= last_length then
+            awesome.emit_signal(
+                "bling::playerctl::position",
+                position,
+                length,
+                player.player_name
+            )
+            last_position = position
+            last_length = length
         end
     end
 end
 
-function playerctl:set_position(player, position)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:set_position(position * 1000000)
-    end
+local function get_album_art(url)
+    return awful.util.shell
+        .. [[ -c '
+
+tmp_dir="$XDG_CACHE_HOME/awesome/"
+
+if [ -z "$XDG_CACHE_HOME" ]; then
+    tmp_dir="$HOME/.cache/awesome/"
+fi
+
+tmp_cover_path="${tmp_dir}cover.png"
+
+if [ ! -d "$tmp_dir" ]; then
+    mkdir -p $tmp_dir
+fi
+
+curl -s ']]
+        .. url
+        .. [[' --output $tmp_cover_path
+
+echo "$tmp_cover_path"
+']]
 end
 
-function playerctl:set_shuffle(player, shuffle)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:set_shuffle(shuffle)
-    end
-end
-
-function playerctl:cycle_shuffle(player)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:set_shuffle(not player.shuffle)
-    end
-end
-
-function playerctl:set_volume(player, volume)
-    player = player or self._private.manager.players[1]
-    if player then
-        player:set_volume(volume)
-    end
-end
-
-function playerctl:get_manager()
-    return self._private.manager
-end
-
-function playerctl:get_active_player()
-    return self._private.manager.players[1]
-end
-
-function playerctl:get_player_of_name(name)
-    for _, player in ipairs(self._private.manager.players[1]) do
-        if player.name == name then
-            return player
-        end
-    end
-
-    return nil
-end
-
-local function emit_metadata_signal(self, title, artist, artUrl, album, new, player_name)
-    title = gstring.xml_escape(title)
-    artist = gstring.xml_escape(artist)
-    album = gstring.xml_escape(album)
-
-    -- Spotify client doesn't report its art URL's correctly...
-    if player_name == "spotify" then
-        artUrl = artUrl:gsub("open.spotify.com", "i.scdn.co")
-    end
-
-    if artUrl ~= "" then
-        local get_art_script = awful.util.shell .. [[ -c '
-            tmp_cover_path=]] .. os.tmpname() .. [[.png
-            curl -s ']] .. artUrl .. [[' --output $tmp_cover_path
-            echo "$tmp_cover_path"
-        ']]
-
-        awful.spawn.with_line_callback(get_art_script, {
-            stdout = function(line)
-                self:emit_signal("metadata", title, artist, line, album, new, player_name)
-            end
-        })
-    else
-        self:emit_signal("metadata", title, artist, "", album, new, player_name)
-    end
-end
-
-local function metadata_cb(self, player, metadata)
-    if self.update_on_activity then
-        self._private.manager:move_player_to_top(player)
+-- Metadata callback for title, artist, and album art
+local last_player = nil
+local last_title = ""
+local last_artist = ""
+local last_artUrl = ""
+local function metadata_cb(player, metadata)
+    if update_on_activity then
+        manager:move_player_to_top(player)
     end
 
     local data = metadata.value
@@ -217,133 +93,101 @@ local function metadata_cb(self, player, metadata)
         artist = artist .. ", " .. data["xesam:artist"][i]
     end
     local artUrl = data["mpris:artUrl"] or ""
-    local album = data["xesam:album"] or ""
+    -- Spotify client doesn't report its art URL's correctly...
+    if player.player_name == "spotify" then
+        artUrl = artUrl:gsub("open.spotify.com", "i.scdn.co")
+    end
 
-    if player == self._private.manager.players[1] then
-        self._private.active_player = player
-
+    if player == manager.players[1] then
         -- Callback can be called even though values we care about haven't
         -- changed, so check to see if they have
         if
-            player ~= self._private.last_player
-            or title ~= self._private.last_title
-            or artist ~= self._private.last_artist
-            or artUrl ~= self._private.last_artUrl
+            player ~= last_player
+            or title ~= last_title
+            or artist ~= last_artist
+            or artUrl ~= last_artUrl
         then
-            if (title == "" and artist == "" and artUrl == "") then return end
-
-            if self._private.metadata_timer ~= nil and self._private.metadata_timer.started then
-                self._private.metadata_timer:stop()
+            if title == "" and artist == "" and artUrl == "" then
+                return
             end
 
-            self._private.metadata_timer = gtimer {
-                timeout = self.debounce_delay,
+            if metadata_timer ~= nil then
+                if metadata_timer.started then
+                    metadata_timer:stop()
+                end
+            end
+
+            metadata_timer = gears.timer({
+                timeout = 0.3,
                 autostart = true,
                 single_shot = true,
                 callback = function()
-                    emit_metadata_signal(self, title, artist, artUrl, album, true, player.player_name)
-                end
-            }
+                    if artUrl ~= "" then
+                        awful.spawn.with_line_callback(get_album_art(artUrl), {
+                            stdout = function(line)
+                                awesome.emit_signal(
+                                    "bling::playerctl::title_artist_album",
+                                    title,
+                                    artist,
+                                    line,
+                                    player.player_name
+                                )
+                            end,
+                        })
+                    else
+                        awesome.emit_signal(
+                            "bling::playerctl::title_artist_album",
+                            title,
+                            artist,
+                            "",
+                            player.player_name
+                        )
+                    end
+                end,
+            })
 
             -- Re-sync with position timer when track changes
-            self._private.position_timer:again()
-            self._private.last_player = player
-            self._private.last_title = title
-            self._private.last_artist = artist
-            self._private.last_artUrl = artUrl
+            position_timer:again()
+            last_player = player
+            last_title = title
+            last_artist = artist
+            last_artUrl = artUrl
         end
     end
 end
 
-local function position_cb(self)
-    local player = self._private.manager.players[1]
-    if player then
-
-        local position = player:get_position() / 1000000
-        local length = (player.metadata.value["mpris:length"] or 0) / 1000000
-        if position ~= self._private.last_position or length ~= self._private.last_length then
-            self:emit_signal("position", position, length, player.player_name)
-            self._private.last_position = position
-            self._private.last_length = length
-        end
-    end
-end
-
-local function playback_status_cb(self, player, status)
-    if self.update_on_activity then
-        self._private.manager:move_player_to_top(player)
+-- Playback status callback
+-- Reported as PLAYING, PAUSED, or STOPPED
+local function playback_status_cb(player, status)
+    if update_on_activity then
+        manager:move_player_to_top(player)
     end
 
-    if player == self._private.manager.players[1] then
-        self._private.active_player = player
-
-        -- Reported as PLAYING, PAUSED, or STOPPED
+    if player == manager.players[1] then
         if status == "PLAYING" then
-            self:emit_signal("playback_status", true, player.player_name)
+            awesome.emit_signal(
+                "bling::playerctl::status",
+                true,
+                player.player_name
+            )
         else
-            self:emit_signal("playback_status", false, player.player_name)
+            awesome.emit_signal(
+                "bling::playerctl::status",
+                false,
+                player.player_name
+            )
         end
-    end
-end
-
-local function seeked_cb(self, player, position)
-    if self.update_on_activity then
-        self._private.manager:move_player_to_top(player)
-    end
-
-    if player == self._private.manager.players[1] then
-        self._private.active_player = player
-        self:emit_signal("seeked", position / 1000000, player.player_name)
-    end
-end
-
-local function volume_cb(self, player, volume)
-    if self.update_on_activity then
-        self._private.manager:move_player_to_top(player)
-    end
-
-    if player == self._private.manager.players[1] then
-        self._private.active_player = player
-        self:emit_signal("volume", volume, player.player_name)
-    end
-end
-
-local function loop_status_cb(self, player, loop_status)
-    if self.update_on_activity then
-        self._private.manager:move_player_to_top(player)
-    end
-
-    if player == self._private.manager.players[1] then
-        self._private.active_player = player
-        self:emit_signal("loop_status", loop_status:lower(), player.player_name)
-    end
-end
-
-local function shuffle_cb(self, player, shuffle)
-    if self.update_on_activity then
-        self._private.manager:move_player_to_top(player)
-    end
-
-    if player == self._private.manager.players[1] then
-        self._private.active_player = player
-        self:emit_signal("shuffle", shuffle, player.player_name)
-    end
-end
-
-local function exit_cb(self, player)
-    if player == self._private.manager.players[1] then
-        self:emit_signal("exit", player.player_name)
     end
 end
 
 -- Determine if player should be managed
-local function name_is_selected(self, name)
-    if self.ignore[name.name] then
+local function name_is_selected(name)
+    if ignore[name.name] then
         return false
     end
 
-    if #self.priority > 0 then
-        for _, arg in pairs(self.priority) do
+    if #priority > 0 then
+        for _, arg in pairs(priority) do
             if arg == name.name or arg == "%any" then
                 return true
             end
@@ -355,42 +199,23 @@ local function name_is_selected(self, name)
 end
 
 -- Create new player and connect it to callbacks
-local function init_player(self, name)
-    if name_is_selected(self, name) then
-        local player = self._private.lgi_Playerctl.Player.new_from_name(name)
-        self._private.manager:manage_player(player)
-        player.on_metadata = function(player, metadata)
-            metadata_cb(self, player, metadata)
-        end
-        player.on_playback_status = function(player, playback_status)
-            playback_status_cb(self, player, playback_status)
-        end
-        player.on_seeked = function(player, position)
-            seeked_cb(self, player, position)
-        end
-        player.on_volume = function(player, volume)
-            volume_cb(self, player, volume)
-        end
-        player.on_loop_status = function(player, loop_status)
-            loop_status_cb(self, player, loop_status)
-        end
-        player.on_shuffle = function(player, shuffle_status)
-            shuffle_cb(self, player, shuffle_status)
-        end
-        player.on_exit = function(player, shuffle_status)
-            exit_cb(self, player)
-        end
+local function init_player(name)
+    if name_is_selected(name) then
+        local player = Playerctl.Player.new_from_name(name)
+        manager:manage_player(player)
+        player.on_playback_status = playback_status_cb
+        player.on_metadata = metadata_cb
 
         -- Start position timer if its not already running
-        if not self._private.position_timer.started then
-            self._private.position_timer:again()
+        if not position_timer.started then
+            position_timer:again()
         end
     end
 end
 
 -- Determine if a player name comes before or after another according to the
 -- priority order
-local function player_compare_name(self, name_a, name_b)
+local function player_compare_name(name_a, name_b)
     local any_index = math.huge
     local a_match_index = nil
     local b_match_index = nil
@@ -399,7 +224,7 @@ local function player_compare_name(self, name_a, name_b)
         return 0
     end
 
-    for index, name in ipairs(self.priority) do
+    for index, name in ipairs(priority) do
         if name == "%any" then
             any_index = (any_index == math.huge) and index or any_index
         elseif name == name_a then
@@ -423,137 +248,103 @@ local function player_compare_name(self, name_a, name_b)
 end
 
 -- Sorting function used by manager if a priority order is specified
-local function player_compare(self, a, b)
-    local player_a = self._private.lgi_Playerctl.Player(a)
-    local player_b = self._private.lgi_Playerctl.Player(b)
-    return player_compare_name(self, player_a.player_name, player_b.player_name)
+local function player_compare(a, b)
+    local player_a = Playerctl.Player(a)
+    local player_b = Playerctl.Player(b)
+    return player_compare_name(player_a.player_name, player_b.player_name)
 end
 
-local function get_current_player_info(self, player)
-    local title = player:get_title() or ""
-    local artist = player:get_artist() or ""
-    local artUrl = player:print_metadata_prop("mpris:artUrl") or ""
-    local album = player:get_album() or ""
-
-    emit_metadata_signal(self, title, artist, artUrl, album, false, player.player_name)
-    playback_status_cb(self, player, player.playback_status)
-    volume_cb(self, player, player.volume)
-    loop_status_cb(self, player, player.loop_status)
-    shuffle_cb(self, player, player.shuffle)
-end
-
-local function start_manager(self)
-    self._private.manager = self._private.lgi_Playerctl.PlayerManager()
-
-    if #self.priority > 0 then
-        self._private.manager:set_sort_func(function(a, b)
-            return player_compare(self, a, b)
-        end)
+local function start_manager()
+    manager = Playerctl.PlayerManager()
+    if #priority > 0 then
+        manager:set_sort_func(player_compare)
     end
 
     -- Timer to update track position at specified interval
-    self._private.position_timer = gtimer {
-        timeout = self.interval,
-        callback = function()
-            position_cb(self)
-        end,
-    }
+    position_timer = gears.timer({
+        timeout = interval,
+        callback = position_cb,
+    })
 
     -- Manage existing players on startup
-    for _, name in ipairs(self._private.manager.player_names) do
-        init_player(self, name)
+    for _, name in ipairs(manager.player_names) do
+        init_player(name)
     end
-
-    if self._private.manager.players[1] then
-        get_current_player_info(self, self._private.manager.players[1])
-    end
-
-    local _self = self
 
     -- Callback to manage new players
-    function self._private.manager:on_name_appeared(name)
-        init_player(_self, name)
+    function manager:on_name_appeared(name)
+        init_player(name)
     end
 
-    function self._private.manager:on_player_appeared(player)
-        if player == self.players[1] then
-            _self._private.active_player = player
-        end
-    end
-
-    function self._private.manager:on_player_vanished(player)
-        if #self.players == 0 then
-            _self._private.metadata_timer:stop()
-            _self._private.position_timer:stop()
-            _self:emit_signal("no_players")
-        elseif player == _self._private.active_player then
-            _self._private.active_player = self.players[1]
-            get_current_player_info(_self, self.players[1])
+    -- Callback to check if all players have exited
+    function manager:on_name_vanished(name)
+        if #manager.players == 0 then
+            metadata_timer:stop()
+            position_timer:stop()
+            awesome.emit_signal("bling::playerctl::no_players")
         end
     end
 end
 
-local function parse_args(self, args)
-    self.ignore = {}
-    if type(args.ignore) == "string" then
-        self.ignore[args.ignore] = true
-    elseif type(args.ignore) == "table" then
-        for _, name in pairs(args.ignore) do
-            self.ignore[name] = true
-        end
-    end
+-- Parse arguments
+local function parse_args(args)
+    if args then
+        update_on_activity = args.update_on_activity or update_on_activity
+        interval = args.interval or interval
 
-    self.priority = {}
-    if type(args.player) == "string" then
-        self.priority[1] = args.player
-    elseif type(args.player) == "table" then
-        self.priority = args.player
+        if type(args.ignore) == "string" then
+            ignore[args.ignore] = true
+        elseif type(args.ignore) == "table" then
+            for _, name in pairs(args.ignore) do
+                ignore[name] = true
+            end
+        end
+
+        if type(args.player) == "string" then
+            priority[1] = args.player
+        elseif type(args.player) == "table" then
+            priority = args.player
+        end
     end
 end
 
-local function new(args)
+local function playerctl_enable(args)
     args = args or {}
-
-    local ret = gobject{}
-    gtable.crush(ret, playerctl, true)
-
     -- Grab settings from beautiful variables if not set explicitly
     args.ignore = args.ignore or beautiful.playerctl_ignore
     args.player = args.player or beautiful.playerctl_player
-    ret.update_on_activity = args.update_on_activity or
-                              beautiful.playerctl_update_on_activity or true
-    ret.interval = args.interval or beautiful.playerctl_position_update_interval or 1
-    ret.debounce_delay = args.debounce_delay or beautiful.playerctl_debounce_delay or 0.35
-    parse_args(ret, args)
-
-    ret._private = {}
-
-    -- Metadata callback for title, artist, and album art
-    ret._private.last_player = nil
-    ret._private.last_title = ""
-    ret._private.last_artist = ""
-    ret._private.last_artUrl = ""
-
-    -- Track position callback
-    ret._private.last_position = -1
-    ret._private.last_length = -1
+    args.update_on_activity = args.update_on_activity
+        or beautiful.playerctl_update_on_activity
+    args.interval = args.interval
+        or beautiful.playerctl_position_update_interval
+    parse_args(args)
 
     -- Grab playerctl library
-    ret._private.lgi_Playerctl = require("lgi").Playerctl
-    ret._private.manager = nil
-    ret._private.metadata_timer = nil
-    ret._private.position_timer = nil
+    Playerctl = require("lgi").Playerctl
 
     -- Ensure main event loop has started before starting player manager
-    gtimer.delayed_call(function()
-        start_manager(ret)
-    end)
-
-    return ret
+    gears.timer.delayed_call(start_manager)
 end
 
-function playerctl.mt:__call(...)
-    return new(...)
+local function playerctl_disable()
+    -- Remove manager and timer
+    manager = nil
+    metadata_timer:stop()
+    metadata_timer = nil
+    position_timer:stop()
+    position_timer = nil
+    -- Restore default settings
+    ignore = {}
+    priority = {}
+    update_on_activity = true
+    interval = 1
+    -- Reset default values
+    last_position = -1
+    last_length = -1
+    last_player = nil
+    last_title = ""
+    last_artist = ""
+    last_artUrl = ""
 end
 
-return setmetatable(playerctl, playerctl.mt)
+return { enable = playerctl_enable, disable = playerctl_disable }

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -138,13 +138,7 @@ end
 
 function playerctl:cycle_shuffle()
     local player = self._private.manager.players[1]
-    if player then
-        if player.shuffle == false then
-            player.set_shuffle(player, true)
-        elseif player.shuffle == true then
-            player.set_shuffle(player, false)
-        end
-    end
+    player.set_shuffle(player, not player.shuffle)
 end
 
 function playerctl:set_volume(volume)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -77,7 +77,7 @@ end
 
 function playerctl:play()
     if self._private.manager.players[1] then
-        self._private.manager.players[1].play(self._private.manager.players[1])
+        self._private.manager.players[1]:play()
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -187,7 +187,6 @@ end
 local function metadata_cb(self, player, metadata)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
-        self._private.active_player = player
     end
 
     local data = metadata.value
@@ -201,6 +200,8 @@ local function metadata_cb(self, player, metadata)
     local album = data["xesam:album"] or ""
 
     if player == self._private.manager.players[1] then
+        self._private.active_player = player
+
         -- Callback can be called even though values we care about haven't
         -- changed, so check to see if they have
         if
@@ -237,6 +238,7 @@ end
 local function position_cb(self)
     local player = self._private.manager.players[1]
     if player then
+
         local position = player:get_position() / 1000000
         local length = (player.metadata.value["mpris:length"] or 0) / 1000000
         if position ~= self._private.last_position or length ~= self._private.last_length then
@@ -250,10 +252,11 @@ end
 local function playback_status_cb(self, player, status)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
-        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
+        self._private.active_player = player
+
         -- Reported as PLAYING, PAUSED, or STOPPED
         if status == "PLAYING" then
             self:emit_signal("playback_status", true, player.player_name)
@@ -266,10 +269,10 @@ end
 local function seeked_cb(self, player, position)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
-        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
+        self._private.active_player = player
         self:emit_signal("seeked", position / 1000000, player.player_name)
     end
 end
@@ -277,10 +280,10 @@ end
 local function volume_cb(self, player, volume)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
-        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
+        self._private.active_player = player
         self:emit_signal("volume", volume, player.player_name)
     end
 end
@@ -288,10 +291,10 @@ end
 local function loop_status_cb(self, player, loop_status)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
-        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
+        self._private.active_player = player
         self:emit_signal("loop_status", loop_status:lower(), player.player_name)
     end
 end
@@ -299,10 +302,10 @@ end
 local function shuffle_cb(self, player, shuffle)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
-        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
+        self._private.active_player = player
         self:emit_signal("shuffle", shuffle, player.player_name)
     end
 end

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -22,7 +22,7 @@
 --      volume (number)
 --      player_name (string)
 -- loop_status
---      loop_status (boolean)
+--      loop_status (string)
 --      player_name (string)
 -- shuffle
 --      shuffle (boolean)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -46,6 +46,30 @@ local type = type
 local playerctl = { mt = {} }
 local instance = nil
 
+function playerctl:disable()
+    -- Restore default settings
+    self.ignore = {}
+    self.priority = {}
+    self.update_on_activity = true
+    self.interval = 1
+    self.debounce_delay = 0.35
+
+    -- Reset timers
+    self._private.manager = nil
+    self._private.metadata_timer:stop()
+    self._private.metadata_timer = nil
+    self._private.position_timer:stop()
+    self._private.position_timer = nil
+
+    -- Reset default values
+    self._private.last_position = -1
+    self._private.last_length = -1
+    self._private.last_player = nil
+    self._private.last_title = ""
+    self._private.last_artist = ""
+    self._private.last_artUrl = ""
+end
+
 function playerctl:pause()
     if self._private.manager.players[1] then
         self._private.manager.players[1].pause(self._private.manager.players[1])

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -107,7 +107,7 @@ end
 
 function playerctl:set_loop_status(loop_status)
     if self._private.manager.players[1] then
-        self._private.manager.players[1].set_loop_status(self._private.manager.players[1], loop_status)
+        self._private.manager.players[1]:set_loop_status(loop_status)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -15,6 +15,12 @@
 -- playback_status
 --      playing (boolean)
 --      player_name (string)
+-- volume
+--      volume (number)
+--      player_name (string)
+-- loop_status
+--      loop_status (boolean)
+--      player_name (string)
 -- shuffle
 --      shuffle (boolean)
 --      player_name (string)
@@ -221,6 +227,26 @@ local function playback_status_cb(self, player, status)
     end
 end
 
+local function volume_cb(self, player, volume)
+    if update_on_activity then
+        manager:move_player_to_top(player)
+    end
+
+    if player == manager.players[1] then
+        self:emit_signal("volume", volume, player.volume)
+    end
+end
+
+local function loop_status_cb(self, player, loop_status)
+    if update_on_activity then
+        manager:move_player_to_top(player)
+    end
+
+    if player == manager.players[1] then
+        self:emit_signal("loop_status", loop_status, player.volume)
+    end
+end
+
 local function shuffle_cb(self, player, shuffle)
     if update_on_activity then
         manager:move_player_to_top(player)
@@ -259,6 +285,12 @@ local function init_player(self, name)
         end
         player.on_playback_status = function(player, playback_status)
             playback_status_cb(self, player, playback_status)
+        end
+        player.on_volume = function(player, volume)
+            volume_cb(self, player, volume)
+        end
+        player.on_loop_status = function(player, loop_status)
+            loop_status_cb(self, player, loop_status)
         end
         player.on_shuffle = function(player, shuffle_status)
             shuffle_cb(self, player, shuffle_status)
@@ -320,6 +352,8 @@ local function get_current_player_info(self, player)
 
     emit_metadata_signal(self, title, artist, artUrl, player.player_name, album, true)
     playback_status_cb(self, player, player.playback_status)
+    volume_cb(self, player, player.volume)
+    loop_status_cb(self, player, player.loop_status)
     shuffle_cb(self, player, player.shuffle)
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -83,7 +83,7 @@ end
 
 function playerctl:stop()
     if self._private.manager.players[1] then
-        self._private.manager.players[1].stop(self._private.manager.players[1])
+        self._private.manager.players[1]:stop()
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -404,7 +404,7 @@ local function get_current_player_info(self, player)
     local artUrl = player:print_metadata_prop("mpris:artUrl") or ""
     local album = player:get_album() or ""
 
-    emit_metadata_signal(self, title, artist, artUrl, player.player_name, album, false)
+    emit_metadata_signal(self, title, artist, artUrl, album, false, player.player_name)
     playback_status_cb(self, player, player.playback_status)
     volume_cb(self, player, player.volume)
     loop_status_cb(self, player, player.loop_status)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -83,6 +83,19 @@ function playerctl:set_loop_status(loop_status)
     end
 end
 
+function playerctl:cycle_loop_status()
+    local player = self._private.manager.players[1]
+    if player then
+        if player.loop_status == "NONE" then
+            player.set_loop_status(player, "TRACK")
+        elseif player.loop_status == "TRACK" then
+            player.set_loop_status(player, "PLAYLIST")
+        elseif player.loop_status == "PLAYLIST" then
+            player.set_loop_status(player, "NONE")
+        end
+    end
+end
+
 function playerctl:set_position()
     if self._private.manager.players[1] then
         -- Disabled as it throws:
@@ -94,6 +107,17 @@ end
 function playerctl:set_shuffle(shuffle)
     if self._private.manager.players[1] then
         self._private.manager.players[1].set_shuffle(self._private.manager.players[1], shuffle)
+    end
+end
+
+function playerctl:cycle_shuffle()
+    local player = self._private.manager.players[1]
+    if player then
+        if player.shuffle == false then
+            player.set_shuffle(player, true)
+        elseif player.shuffle == true then
+            player.set_shuffle(player, false)
+        end
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -5,9 +5,9 @@
 --      title (string)
 --      artist  (string)
 --      album_path (string)
---      player_name (string)
 --      album (string)
 --      new (bool)
+--      player_name (string)
 -- position
 --      interval_sec (number)
 --      length_sec (number)
@@ -180,13 +180,13 @@ local function emit_metadata_signal(self, title, artist, artUrl, player_name, al
 
         awful.spawn.with_line_callback(get_art_script, {
             stdout = function(line)
-                self:emit_signal("metadata", title, artist, line, player_name,
-                                                  album, new)
+                self:emit_signal("metadata", title, artist, line, album,
+                                new, player_name)
             end
         })
     else
-        self:emit_signal("metadata", title, artist, "", player_name,
-                                          album, new)
+        self:emit_signal("metadata", title, artist, "", album,
+                        new, player_name)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -44,11 +44,8 @@ local pairs = pairs
 local type = type
 
 local playerctl = { mt = {} }
-local instance = nil
 
 function playerctl:disable()
-    instance = nil
-
     -- Restore default settings
     self.ignore = {}
     self.priority = {}
@@ -527,10 +524,7 @@ local function new(args)
 end
 
 function playerctl.mt:__call(...)
-    if not instance then
-        instance = new(...)
-    end
-    return instance
+    return new(...)
 end
 
 return setmetatable(playerctl, playerctl.mt)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -101,7 +101,7 @@ end
 
 function playerctl:next()
     if self._private.manager.players[1] then
-        self._private.manager.players[1].next(self._private.manager.players[1])
+        self._private.manager.players[1]:next()
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -296,7 +296,7 @@ local function loop_status_cb(self, player, loop_status)
     end
 
     if player == self._private.manager.players[1] then
-        self:emit_signal("loop_status", loop_status, player.player_name)
+        self:emit_signal("loop_status", loop_status:lower(), player.player_name)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -444,13 +444,19 @@ local function start_manager(self)
         init_player(_self, name)
     end
 
-    -- Callback to check if all players have exited
-    function self._private.manager:on_name_vanished(name)
-        if #self.players == 0 then
+    function self._private.manager:on_player_appeared(player)
+        if player == self.players[1] then
+            _self._private.active_player = player
+        end
+    end
+
+    function self._private.manager:on_player_vanished(player)
+        if self.players == 0 then
             _self._private.metadata_timer:stop()
             _self._private.position_timer:stop()
             _self:emit_signal("no_players")
-        else
+        elseif player == _self._private.active_player then
+            _self._private.active_player = self.players[1]
             get_current_player_info(_self, self.players[1])
         end
     end

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -96,11 +96,9 @@ function playerctl:cycle_loop_status()
     end
 end
 
-function playerctl:set_position()
+function playerctl:set_position(position)
     if self._private.manager.players[1] then
-        -- Disabled as it throws:
-        -- (process:115888): GLib-CRITICAL **: 09:53:03.111: g_variant_new_object_path: assertion 'g_variant_is_object_path (object_path)' failed
-        --self._private.manager.players[1].set_position(self._private.manager.players[1], 1000)
+        self._private.manager.players[1].set_position(self._private.manager.players[1], position)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -115,7 +115,7 @@ function playerctl:cycle_loop_status()
     local player = self._private.manager.players[1]
     if player then
         if player.loop_status == "NONE" then
-            player.set_loop_status(player, "TRACK")
+            player:set_loop_status("TRACK")
         elseif player.loop_status == "TRACK" then
             player.set_loop_status(player, "PLAYLIST")
         elseif player.loop_status == "PLAYLIST" then

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -119,7 +119,7 @@ function playerctl:cycle_loop_status()
         elseif player.loop_status == "TRACK" then
             player:set_loop_status("PLAYLIST")
         elseif player.loop_status == "PLAYLIST" then
-            player.set_loop_status(player, "NONE")
+            player:set_loop_status("NONE")
         end
     end
 end

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -446,7 +446,7 @@ local function start_manager(self)
 
     -- Callback to check if all players have exited
     function self._private.manager:on_name_vanished(name)
-        if #_self._private.manager.players == 0 then
+        if #self.players == 0 then
             _self._private.metadata_timer:stop()
             _self._private.position_timer:stop()
             _self:emit_signal("no_players")

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -439,8 +439,8 @@ local function new(args)
     args.update_on_activity = args.update_on_activity or
                               beautiful.playerctl_update_on_activity
     args.interval = args.interval or beautiful.playerctl_position_update_interval
-    args.debounce_delay = args.debounce_delay or beautiful.playerctl_position_update_debounce_delay
     parse_args(args)
+    args.debounce_delay = args.debounce_delay or beautiful.playerctl_debounce_delay
 
     -- Grab playerctl library
     lgi_Playerctl = require("lgi").Playerctl

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -15,6 +15,9 @@
 -- playback_status
 --      playing (boolean)
 --      player_name (string)
+-- seeked
+--      position (number)
+--      player_name (string)
 -- volume
 --      volume (number)
 --      player_name (string)
@@ -23,6 +26,8 @@
 --      player_name (string)
 -- shuffle
 --      shuffle (boolean)
+--      player_name (string)
+-- exit
 --      player_name (string)
 -- no_players
 --      (No parameters)
@@ -239,6 +244,16 @@ local function playback_status_cb(self, player, status)
     end
 end
 
+local function seeked_cb(self, player, position)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    if player == self._private.manager.players[1] then
+        self:emit_signal("seeked", position, player.player_name)
+    end
+end
+
 local function volume_cb(self, player, volume)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
@@ -266,6 +281,12 @@ local function shuffle_cb(self, player, shuffle)
 
     if player == self._private.manager.players[1] then
         self:emit_signal("shuffle", shuffle, player.player_name)
+    end
+end
+
+local function exit_cb(self, player)
+    if player == self._private.manager.players[1] then
+        self:emit_signal("exit", player.player_name)
     end
 end
 
@@ -298,6 +319,9 @@ local function init_player(self, name)
         player.on_playback_status = function(player, playback_status)
             playback_status_cb(self, player, playback_status)
         end
+        player.on_seeked = function(player, position)
+            seeked_cb(self, player, position)
+        end
         player.on_volume = function(player, volume)
             volume_cb(self, player, volume)
         end
@@ -306,6 +330,9 @@ local function init_player(self, name)
         end
         player.on_shuffle = function(player, shuffle_status)
             shuffle_cb(self, player, shuffle_status)
+        end
+        player.on_exit = function(player, shuffle_status)
+            exit_cb(self, player)
         end
 
         -- Start position timer if its not already running

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -143,7 +143,7 @@ end
 
 function playerctl:set_volume(volume)
     if self._private.manager.players[1] then
-        self._private.manager.players[1].set_volume(self._private.manager.players[1], volume)
+        self._private.manager.players[1]:set_volume(volume)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -155,7 +155,7 @@ function playerctl:get_active_player()
     return self._private.manager.players[1]
 end
 
-local function emit_metadata_signal(self, title, artist, artUrl, player_name, album, new)
+local function emit_metadata_signal(self, title, artist, artUrl, album, new, player_name)
     title = gstring.xml_escape(title)
     artist = gstring.xml_escape(artist)
     album = gstring.xml_escape(album)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -187,6 +187,7 @@ end
 local function metadata_cb(self, player, metadata)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
+        self._private.active_player = player
     end
 
     local data = metadata.value
@@ -249,6 +250,7 @@ end
 local function playback_status_cb(self, player, status)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
+        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
@@ -264,6 +266,7 @@ end
 local function seeked_cb(self, player, position)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
+        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
@@ -274,6 +277,7 @@ end
 local function volume_cb(self, player, volume)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
+        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
@@ -284,6 +288,7 @@ end
 local function loop_status_cb(self, player, loop_status)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
+        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then
@@ -294,6 +299,7 @@ end
 local function shuffle_cb(self, player, shuffle)
     if self.update_on_activity then
         self._private.manager:move_player_to_top(player)
+        self._private.active_player = player
     end
 
     if player == self._private.manager.players[1] then

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -451,7 +451,7 @@ local function start_manager(self)
             _self._private.position_timer:stop()
             _self:emit_signal("no_players")
         else
-            get_current_player_info(_self, _self._private.manager.players[1])
+            get_current_player_info(_self, self.players[1])
         end
     end
 end

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -117,7 +117,7 @@ function playerctl:cycle_loop_status()
         if player.loop_status == "NONE" then
             player:set_loop_status("TRACK")
         elseif player.loop_status == "TRACK" then
-            player.set_loop_status(player, "PLAYLIST")
+            player:set_loop_status("PLAYLIST")
         elseif player.loop_status == "PLAYLIST" then
             player.set_loop_status(player, "NONE")
         end

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -124,6 +124,14 @@ function playerctl:set_volume(volume)
     end
 end
 
+function playerctl:get_manager()
+    return manager
+end
+
+function playerctl:get_active_player()
+    return manager.players[1]
+end
+
 local function emit_metadata_signal(self, title, artist, artUrl, player_name, album, new)
     title = gstring.xml_escape(title)
     artist = gstring.xml_escape(artist)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -47,6 +47,8 @@ local playerctl = { mt = {} }
 local instance = nil
 
 function playerctl:disable()
+    instance = nil
+
     -- Restore default settings
     self.ignore = {}
     self.priority = {}

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -126,7 +126,7 @@ end
 
 function playerctl:set_position(position)
     if self._private.manager.players[1] then
-        self._private.manager.players[1].set_position(self._private.manager.players[1], position * 1000000)
+        self._private.manager.players[1]:set_position(position * 1000000)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -157,6 +157,16 @@ function playerctl:get_active_player()
     return self._private.manager.players[1]
 end
 
+function playerctl:get_player_of_name(name)
+    for _, player in ipairs(self._private.manager.players[1]) do
+        if player.name == name then
+            return player
+        end
+    end
+
+    return nil
+end
+
 local function emit_metadata_signal(self, title, artist, artUrl, album, new, player_name)
     title = gstring.xml_escape(title)
     artist = gstring.xml_escape(artist)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -138,7 +138,9 @@ end
 
 function playerctl:cycle_shuffle()
     local player = self._private.manager.players[1]
-    player.set_shuffle(player, not player.shuffle)
+    if player then
+        player:set_shuffle(not player.shuffle)
+    end
 end
 
 function playerctl:set_volume(volume)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -282,68 +282,6 @@ local function start_manager()
             get_current_player_info(manager.players[1])
         end
     end
-
-    awesome.connect_signal("bling::playerctl::pause", function()
-        if manager.players[1] then
-            manager.players[1].pause(manager.players[1])
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::play", function()
-        if manager.players[1] then
-            manager.players[1].play(manager.players[1])
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::stop", function()
-        if manager.players[1] then
-            manager.players[1].stop(manager.players[1])
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::play_pause", function()
-        if manager.players[1] then
-            manager.players[1].play_pause(manager.players[1])
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::previous", function()
-        if manager.players[1] then
-            manager.players[1].previous(manager.players[1])
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::next", function()
-        if manager.players[1] then
-            manager.players[1].next(manager.players[1])
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::set_loop_status", function(loop_status)
-        if manager.players[1] then
-            manager.players[1].set_loop_status(manager.players[1], loop_status)
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::set_position", function(position)
-        if manager.players[1] then
-            -- Disabled as it throws:
-            -- (process:115888): GLib-CRITICAL **: 09:53:03.111: g_variant_new_object_path: assertion 'g_variant_is_object_path (object_path)' failed
-            --manager.players[1].set_position(manager.players[1], 1000)
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::set_shuffle", function(shuffle)
-        if manager.players[1] then
-            manager.players[1].set_shuffle(manager.players[1], shuffle)
-        end
-    end)
-
-    awesome.connect_signal("bling::playerctl::set_volume", function(volume)
-        if manager.players[1] then
-            manager.players[1].set_volume(manager.players[1], volume)
-        end
-    end)
 end
 
 -- Parse arguments
@@ -407,17 +345,6 @@ local function playerctl_disable()
     last_title = ""
     last_artist = ""
     last_artUrl = ""
-
-    awesome.disconnect_signal("bling::playerctl::pause")
-    awesome.disconnect_signal("bling::playerctl::play")
-    awesome.disconnect_signal("bling::playerctl::stop")
-    awesome.disconnect_signal("bling::playerctl::play_pause")
-    awesome.disconnect_signal("bling::playerctl::previous")
-    awesome.disconnect_signal("bling::playerctl::next")
-    awesome.disconnect_signal("bling::playerctl::set_loop_status")
-    awesome.disconnect_signal("bling::playerctl::set_position")
-    awesome.disconnect_signal("bling::playerctl::set_shuffle")
-    awesome.disconnect_signal("bling::playerctl::set_volume")
 end
 
 return {enable = playerctl_enable, disable = playerctl_disable}

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -468,6 +468,7 @@ local function start_manager(self)
 end
 
 local function parse_args(self, args)
+    self.ignore = {}
     if type(args.ignore) == "string" then
         self.ignore[args.ignore] = true
     elseif type(args.ignore) == "table" then
@@ -476,6 +477,7 @@ local function parse_args(self, args)
         end
     end
 
+    self.priority = {}
     if type(args.player) == "string" then
         self.priority[1] = args.player
     elseif type(args.player) == "table" then
@@ -490,8 +492,8 @@ local function new(args)
     gtable.crush(ret, playerctl, true)
 
     -- Grab settings from beautiful variables if not set explicitly
-    ret.ignore = args.ignore or beautiful.playerctl_ignore or {}
-    ret.priority = args.player or beautiful.playerctl_player or {}
+    args.ignore = args.ignore or beautiful.playerctl_ignore
+    args.player = args.player or beautiful.playerctl_player
     ret.update_on_activity = args.update_on_activity or
                               beautiful.playerctl_update_on_activity or true
     ret.interval = args.interval or beautiful.playerctl_position_update_interval or 1

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -98,7 +98,7 @@ end
 
 function playerctl:set_position(position)
     if self._private.manager.players[1] then
-        self._private.manager.players[1].set_position(self._private.manager.players[1], position)
+        self._private.manager.players[1].set_position(self._private.manager.players[1], position * 1000000)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -132,7 +132,7 @@ end
 
 function playerctl:set_shuffle(shuffle)
     if self._private.manager.players[1] then
-        self._private.manager.players[1].set_shuffle(self._private.manager.players[1], shuffle)
+        self._private.manager.players[1]:set_shuffle(shuffle)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -89,7 +89,7 @@ end
 
 function playerctl:play_pause()
     if self._private.manager.players[1] then
-        self._private.manager.players[1].play_pause(self._private.manager.players[1])
+        self._private.manager.players[1]:play_pause()
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -223,7 +223,7 @@ local function volume_cb(self, player, volume)
     end
 
     if player == self._private.manager.players[1] then
-        self:emit_signal("volume", volume, player.volume)
+        self:emit_signal("volume", volume, player.player_name)
     end
 end
 
@@ -233,7 +233,7 @@ local function loop_status_cb(self, player, loop_status)
     end
 
     if player == self._private.manager.players[1] then
-        self:emit_signal("loop_status", loop_status, player.volume)
+        self:emit_signal("loop_status", loop_status, player.player_name)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -389,7 +389,7 @@ local function get_current_player_info(self, player)
     local artUrl = self._private.lgi_Playerctl.Player.print_metadata_prop(player, "mpris:artUrl") or ""
     local album = self._private.lgi_Playerctl.Player.get_album(player) or ""
 
-    emit_metadata_signal(self, title, artist, artUrl, player.player_name, album, true)
+    emit_metadata_signal(self, title, artist, artUrl, player.player_name, album, false)
     playback_status_cb(self, player, player.playback_status)
     volume_cb(self, player, player.volume)
     loop_status_cb(self, player, player.loop_status)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -71,7 +71,7 @@ end
 
 function playerctl:pause()
     if self._private.manager.players[1] then
-        self._private.manager.players[1].pause(self._private.manager.players[1])
+        self._private.manager.players[1]:pause()
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -273,7 +273,7 @@ local function seeked_cb(self, player, position)
     end
 
     if player == self._private.manager.players[1] then
-        self:emit_signal("seeked", position, player.player_name)
+        self:emit_signal("seeked", position / 1000000, player.player_name)
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -95,7 +95,7 @@ end
 
 function playerctl:previous()
     if self._private.manager.players[1] then
-        self._private.manager.players[1].previous(self._private.manager.players[1])
+        self._private.manager.players[1]:previous()
     end
 end
 

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -399,10 +399,10 @@ local function player_compare(self, a, b)
 end
 
 local function get_current_player_info(self, player)
-    local title = self._private.lgi_Playerctl.Player.get_title(player) or ""
-    local artist = self._private.lgi_Playerctl.Player.get_artist(player) or ""
-    local artUrl = self._private.lgi_Playerctl.Player.print_metadata_prop(player, "mpris:artUrl") or ""
-    local album = self._private.lgi_Playerctl.Player.get_album(player) or ""
+    local title = player:get_title() or ""
+    local artist = player:get_artist() or ""
+    local artUrl = player:print_metadata_prop("mpris:artUrl") or ""
+    local album = player:get_album() or ""
 
     emit_metadata_signal(self, title, artist, artUrl, player.player_name, album, false)
     playback_status_cb(self, player, player.playback_status)

--- a/signal/playerctl_v2/init.lua
+++ b/signal/playerctl_v2/init.lua
@@ -1,0 +1,5 @@
+return
+{
+    cli = require(... .. ".playerctl_cli"),
+    lib = require(... .. ".playerctl_lib")
+}

--- a/signal/playerctl_v2/playerctl_cli.lua
+++ b/signal/playerctl_v2/playerctl_cli.lua
@@ -1,0 +1,347 @@
+-- Playerctl signals
+--
+-- Provides:
+-- metadata
+--      title (string)
+--      artist  (string)
+--      album_path (string)
+--      album (string)
+--      player_name (string)
+-- position
+--      interval_sec (number)
+--      length_sec (number)
+-- playback_status
+--      playing (boolean)
+-- volume
+--      volume (number)
+-- loop_status
+--      loop_status (string)
+-- shuffle
+--      shuffle (bool)
+-- no_players
+--      (No parameters)
+
+local awful = require("awful")
+local gobject = require("gears.object")
+local gtable = require("gears.table")
+local gtimer = require("gears.timer")
+local gstring = require("gears.string")
+local beautiful = require("beautiful")
+local setmetatable = setmetatable
+local tonumber = tonumber
+local ipairs = ipairs
+local type = type
+
+local playerctl = { mt = {} }
+
+function playerctl:disable()
+    self._private.metadata_timer:stop()
+    self._private.metadata_timer = nil
+    awful.spawn.with_shell("killall playerctl")
+end
+
+function playerctl:pause(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " pause")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "pause")
+    end
+end
+
+function playerctl:play(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " play")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "play")
+    end
+end
+
+function playerctl:stop(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " stop")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "stop")
+    end
+end
+
+function playerctl:play_pause(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " play-pause")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "play-pause")
+    end
+end
+
+function playerctl:previous(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " previous")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "previous")
+    end
+end
+
+function playerctl:next(player)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " next")
+    else
+        awful.spawn.with_shell(self._private.cmd .. "next")
+    end
+end
+
+function playerctl:set_loop_status(player, loop_status)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " loop " .. loop_status)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "loop " .. loop_status)
+    end
+end
+
+function playerctl:cycle_loop_status(player)
+    local function set_loop_status(loop_status)
+        if loop_status == "None" then
+            self:set_loop_status("Track")
+        elseif loop_status == "Track" then
+            self:set_loop_status("Playlist")
+        elseif loop_status == "Playlist" then
+            self:set_loop_status("None")
+        end
+    end
+
+    if player ~= nil then
+        awful.spawn.easy_async_with_shell("playerctl --player=" .. player .. " loop", function(stdout)
+            set_loop_status(stdout)
+        end)
+    else
+        set_loop_status(self._private.loop_status)
+    end
+end
+
+function playerctl:set_position(player, position)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " position " .. position)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "position " .. position)
+    end
+end
+
+function playerctl:set_shuffle(player, shuffle)
+    shuffle = shuffle and "on" or "off"
+
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " shuffle " .. shuffle)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "shuffle " .. shuffle)
+    end
+end
+
+function playerctl:cycle_shuffle(player)
+    if player ~= nil then
+        awful.spawn.easy_async_with_shell("playerctl --player=" .. player .. " shuffle", function(stdout)
+            local shuffle = stdout == "on" and true or false
+            self:set_shuffle(not self._private.shuffle)
+        end)
+    else
+        self:set_shuffle(not self._private.shuffle)
+    end
+end
+
+function playerctl:set_volume(player, volume)
+    if player ~= nil then
+        awful.spawn.with_shell("playerctl --player=" .. player .. " volume " .. volume)
+    else
+        awful.spawn.with_shell(self._private.cmd .. "volume " .. volume)
+    end
+end
+
+local function emit_player_metadata(self)
+    local metadata_cmd = self._private.cmd .. "metadata --format 'title_{{title}}artist_{{artist}}art_url_{{mpris:artUrl}}player_name_{{playerName}}album_{{album}}' -F"
+
+    awful.spawn.with_line_callback(metadata_cmd, {
+        stdout = function(line)
+            local title = gstring.xml_escape(line:match('title_(.*)artist_')) or ""
+            local artist = gstring.xml_escape(line:match('artist_(.*)art_url_')) or ""
+            local art_url = line:match('art_url_(.*)player_name_') or ""
+            local player_name = line:match('player_name_(.*)album_') or ""
+            local album = gstring.xml_escape(line:match('album_(.*)')) or ""
+
+            art_url = art_url:gsub('%\n', '')
+            if player_name == "spotify" then
+                art_url = art_url:gsub("open.spotify.com", "i.scdn.co")
+            end
+
+            if self._private.metadata_timer
+                and self._private.metadata_timer.started
+            then
+                self._private.metadata_timer:stop()
+            end
+
+            self._private.metadata_timer = gtimer {
+                timeout = self.debounce_delay,
+                autostart = true,
+                single_shot = true,
+                callback = function()
+                    if title and title ~= "" then
+                        if art_url ~= "" then
+                            local get_art_script = awful.util.shell .. [[ -c '
+                                tmp_cover_path=]] .. os.tmpname() .. [[.png
+                                curl -s ']] .. art_url .. [[' --output $tmp_cover_path
+                                echo "$tmp_cover_path"
+                            ']]
+
+                            awful.spawn.with_line_callback(get_art_script, {
+                                stdout = function(stdout)
+                                    self:emit_signal("metadata", title, artist, stdout, album, player_name)
+                                end
+                            })
+                        else
+                            self:emit_signal("metadata", title, artist, "", album, player_name)
+                        end
+                    else
+                        self:emit_signal("no_players")
+                    end
+                end
+            }
+
+            collectgarbage("collect")
+        end,
+    })
+end
+
+local function emit_player_position(self)
+    local position_cmd = self._private.cmd .. "position"
+    local length_cmd = self._private.cmd .. "metadata mpris:length"
+
+    awful.widget.watch(position_cmd, self.interval, function(_, interval)
+        awful.spawn.easy_async_with_shell(length_cmd, function(length)
+            local length_sec = tonumber(length) -- in microseconds
+            local interval_sec = tonumber(interval) -- in seconds
+            if length_sec and interval_sec then
+                if interval_sec >= 0 and length_sec > 0 then
+                    self:emit_signal("position", interval_sec, length_sec / 1000000)
+                end
+            end
+        end)
+        collectgarbage("collect")
+    end)
+end
+
+local function emit_player_playback_status(self)
+    local status_cmd = self._private.cmd .. "status -F"
+
+    awful.spawn.with_line_callback(status_cmd, {
+        stdout = function(line)
+            if line:find("Playing") then
+                self:emit_signal("playback_status", true)
+            else
+                self:emit_signal("playback_status", false)
+            end
+        end,
+    })
+end
+
+local function emit_player_volume(self)
+    local volume_cmd = self._private.cmd .. "volume -F"
+
+    awful.spawn.with_line_callback(volume_cmd, {
+        stdout = function(line)
+            self:emit_signal("volume", tonumber(line))
+        end,
+    })
+end
+
+local function emit_player_loop_status(self)
+    local loop_status_cmd = self._private.cmd .. "loop -F"
+
+    awful.spawn.with_line_callback(loop_status_cmd, {
+        stdout = function(line)
+            self._private.loop_status = line
+            self:emit_signal("loop_status", line:lower())
+        end,
+    })
+end
+
+local function emit_player_shuffle(self)
+    local shuffle_cmd = self._private.cmd .. "shuffle -F"
+
+    awful.spawn.with_line_callback(shuffle_cmd, {
+        stdout = function(line)
+            if line:find("On") then
+                self._private.shuffle = true
+                self:emit_signal("shuffle", true)
+            else
+                self._private.shuffle = false
+                self:emit_signal("shuffle", false)
+            end
+        end,
+    })
+end
+
+local function parse_args(self, args)
+    if args.player then
+        self._private.cmd = self._private.cmd .. "--player="
+
+        if type(args.player) == "string" then
+            self._private.cmd = self._private.cmd .. args.player .. " "
+        elseif type(args.player) == "table" then
+            for index, player in ipairs(args.player) do
+                self._private.cmd = self._private.cmd .. player
+                if index < #args.player then
+                    self._private.cmd = self._private.cmd .. ","
+                else
+                    self._private.cmd = self._private.cmd .. " "
+                end
+            end
+        end
+    end
+
+    if args.ignore then
+        self._private.cmd = self._private.cmd .. "--ignore-player="
+
+        if type(args.ignore) == "string" then
+            self._private.cmd = self._private.cmd .. args.ignore .. " "
+        elseif type(args.ignore) == "table" then
+            for index, player in ipairs(args.ignore) do
+                self._private.cmd = self._private.cmd .. player
+                if index < #args.ignore then
+                    self._private.cmd = self._private.cmd .. ","
+                else
+                    self._private.cmd = self._private.cmd .. " "
+                end
+            end
+        end
+    end
+end
+
+local function new(args)
+    args = args or {}
+
+    local ret = gobject{}
+    gtable.crush(ret, playerctl, true)
+
+    ret.interval = args.interval or beautiful.playerctl_position_update_interval or 1
+    ret.debounce_delay = args.debounce_delay or beautiful.playerctl_debounce_delay or 0.35
+
+    ret._private = {}
+    ret._private.metadata_timer = nil
+    ret._private.cmd = "playerctl "
+    parse_args(ret, args)
+
+    emit_player_metadata(ret)
+    emit_player_position(ret)
+    emit_player_playback_status(ret)
+    emit_player_volume(ret)
+    emit_player_loop_status(ret)
+    emit_player_shuffle(ret)
+
+    return ret
+end
+
+function playerctl.mt:__call(...)
+    return new(...)
+end
+
+-- On startup instead of on playerctl object init to make it
+-- possible to have more than one of these running
+awful.spawn.with_shell("killall playerctl")
+
+return setmetatable(playerctl, playerctl.mt)

--- a/signal/playerctl_v2/playerctl_lib.lua
+++ b/signal/playerctl_v2/playerctl_lib.lua
@@ -1,0 +1,559 @@
+-- Playerctl signals
+--
+-- Provides:
+-- metadata
+--      title (string)
+--      artist  (string)
+--      album_path (string)
+--      album (string)
+--      new (bool)
+--      player_name (string)
+-- position
+--      interval_sec (number)
+--      length_sec (number)
+--      player_name (string)
+-- playback_status
+--      playing (boolean)
+--      player_name (string)
+-- seeked
+--      position (number)
+--      player_name (string)
+-- volume
+--      volume (number)
+--      player_name (string)
+-- loop_status
+--      loop_status (string)
+--      player_name (string)
+-- shuffle
+--      shuffle (boolean)
+--      player_name (string)
+-- exit
+--      player_name (string)
+-- no_players
+--      (No parameters)
+
+local awful = require("awful")
+local gobject = require("gears.object")
+local gtable = require("gears.table")
+local gtimer = require("gears.timer")
+local gstring = require("gears.string")
+local beautiful = require("beautiful")
+local setmetatable = setmetatable
+local ipairs = ipairs
+local pairs = pairs
+local type = type
+
+local playerctl = { mt = {} }
+
+function playerctl:disable()
+    -- Restore default settings
+    self.ignore = {}
+    self.priority = {}
+    self.update_on_activity = true
+    self.interval = 1
+    self.debounce_delay = 0.35
+
+    -- Reset timers
+    self._private.manager = nil
+    self._private.metadata_timer:stop()
+    self._private.metadata_timer = nil
+    self._private.position_timer:stop()
+    self._private.position_timer = nil
+
+    -- Reset default values
+    self._private.last_position = -1
+    self._private.last_length = -1
+    self._private.last_player = nil
+    self._private.last_title = ""
+    self._private.last_artist = ""
+    self._private.last_artUrl = ""
+end
+
+function playerctl:pause(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:pause()
+    end
+end
+
+function playerctl:play(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:play()
+    end
+end
+
+function playerctl:stop(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:stop()
+    end
+end
+
+function playerctl:play_pause(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:play_pause()
+    end
+end
+
+function playerctl:previous(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:previous()
+    end
+end
+
+function playerctl:next(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:next()
+    end
+end
+
+function playerctl:set_loop_status(player, loop_status)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_loop_status(loop_status)
+    end
+end
+
+function playerctl:cycle_loop_status(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        if player.loop_status == "NONE" then
+            player:set_loop_status("TRACK")
+        elseif player.loop_status == "TRACK" then
+            player:set_loop_status("PLAYLIST")
+        elseif player.loop_status == "PLAYLIST" then
+            player:set_loop_status("NONE")
+        end
+    end
+end
+
+function playerctl:set_position(player, position)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_position(position * 1000000)
+    end
+end
+
+function playerctl:set_shuffle(player, shuffle)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_shuffle(shuffle)
+    end
+end
+
+function playerctl:cycle_shuffle(player)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_shuffle(not player.shuffle)
+    end
+end
+
+function playerctl:set_volume(player, volume)
+    player = player or self._private.manager.players[1]
+    if player then
+        player:set_volume(volume)
+    end
+end
+
+function playerctl:get_manager()
+    return self._private.manager
+end
+
+function playerctl:get_active_player()
+    return self._private.manager.players[1]
+end
+
+function playerctl:get_player_of_name(name)
+    for _, player in ipairs(self._private.manager.players[1]) do
+        if player.name == name then
+            return player
+        end
+    end
+
+    return nil
+end
+
+local function emit_metadata_signal(self, title, artist, artUrl, album, new, player_name)
+    title = gstring.xml_escape(title)
+    artist = gstring.xml_escape(artist)
+    album = gstring.xml_escape(album)
+
+    -- Spotify client doesn't report its art URL's correctly...
+    if player_name == "spotify" then
+        artUrl = artUrl:gsub("open.spotify.com", "i.scdn.co")
+    end
+
+    if artUrl ~= "" then
+        local get_art_script = awful.util.shell .. [[ -c '
+            tmp_cover_path=]] .. os.tmpname() .. [[.png
+            curl -s ']] .. artUrl .. [[' --output $tmp_cover_path
+            echo "$tmp_cover_path"
+        ']]
+
+        awful.spawn.with_line_callback(get_art_script, {
+            stdout = function(line)
+                self:emit_signal("metadata", title, artist, line, album, new, player_name)
+            end
+        })
+    else
+        self:emit_signal("metadata", title, artist, "", album, new, player_name)
+    end
+end
+
+local function metadata_cb(self, player, metadata)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    local data = metadata.value
+
+    local title = data["xesam:title"] or ""
+    local artist = data["xesam:artist"][1] or ""
+    for i = 2, #data["xesam:artist"] do
+        artist = artist .. ", " .. data["xesam:artist"][i]
+    end
+    local artUrl = data["mpris:artUrl"] or ""
+    local album = data["xesam:album"] or ""
+
+    if player == self._private.manager.players[1] then
+        self._private.active_player = player
+
+        -- Callback can be called even though values we care about haven't
+        -- changed, so check to see if they have
+        if
+            player ~= self._private.last_player
+            or title ~= self._private.last_title
+            or artist ~= self._private.last_artist
+            or artUrl ~= self._private.last_artUrl
+        then
+            if (title == "" and artist == "" and artUrl == "") then return end
+
+            if self._private.metadata_timer ~= nil and self._private.metadata_timer.started then
+                self._private.metadata_timer:stop()
+            end
+
+            self._private.metadata_timer = gtimer {
+                timeout = self.debounce_delay,
+                autostart = true,
+                single_shot = true,
+                callback = function()
+                    emit_metadata_signal(self, title, artist, artUrl, album, true, player.player_name)
+                end
+            }
+
+            -- Re-sync with position timer when track changes
+            self._private.position_timer:again()
+            self._private.last_player = player
+            self._private.last_title = title
+            self._private.last_artist = artist
+            self._private.last_artUrl = artUrl
+        end
+    end
+end
+
+local function position_cb(self)
+    local player = self._private.manager.players[1]
+    if player then
+
+        local position = player:get_position() / 1000000
+        local length = (player.metadata.value["mpris:length"] or 0) / 1000000
+        if position ~= self._private.last_position or length ~= self._private.last_length then
+            self:emit_signal("position", position, length, player.player_name)
+            self._private.last_position = position
+            self._private.last_length = length
+        end
+    end
+end
+
+local function playback_status_cb(self, player, status)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    if player == self._private.manager.players[1] then
+        self._private.active_player = player
+
+        -- Reported as PLAYING, PAUSED, or STOPPED
+        if status == "PLAYING" then
+            self:emit_signal("playback_status", true, player.player_name)
+        else
+            self:emit_signal("playback_status", false, player.player_name)
+        end
+    end
+end
+
+local function seeked_cb(self, player, position)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    if player == self._private.manager.players[1] then
+        self._private.active_player = player
+        self:emit_signal("seeked", position / 1000000, player.player_name)
+    end
+end
+
+local function volume_cb(self, player, volume)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    if player == self._private.manager.players[1] then
+        self._private.active_player = player
+        self:emit_signal("volume", volume, player.player_name)
+    end
+end
+
+local function loop_status_cb(self, player, loop_status)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    if player == self._private.manager.players[1] then
+        self._private.active_player = player
+        self:emit_signal("loop_status", loop_status:lower(), player.player_name)
+    end
+end
+
+local function shuffle_cb(self, player, shuffle)
+    if self.update_on_activity then
+        self._private.manager:move_player_to_top(player)
+    end
+
+    if player == self._private.manager.players[1] then
+        self._private.active_player = player
+        self:emit_signal("shuffle", shuffle, player.player_name)
+    end
+end
+
+local function exit_cb(self, player)
+    if player == self._private.manager.players[1] then
+        self:emit_signal("exit", player.player_name)
+    end
+end
+
+-- Determine if player should be managed
+local function name_is_selected(self, name)
+    if self.ignore[name.name] then
+        return false
+    end
+
+    if #self.priority > 0 then
+        for _, arg in pairs(self.priority) do
+            if arg == name.name or arg == "%any" then
+                return true
+            end
+        end
+        return false
+    end
+
+    return true
+end
+
+-- Create new player and connect it to callbacks
+local function init_player(self, name)
+    if name_is_selected(self, name) then
+        local player = self._private.lgi_Playerctl.Player.new_from_name(name)
+        self._private.manager:manage_player(player)
+        player.on_metadata = function(player, metadata)
+            metadata_cb(self, player, metadata)
+        end
+        player.on_playback_status = function(player, playback_status)
+            playback_status_cb(self, player, playback_status)
+        end
+        player.on_seeked = function(player, position)
+            seeked_cb(self, player, position)
+        end
+        player.on_volume = function(player, volume)
+            volume_cb(self, player, volume)
+        end
+        player.on_loop_status = function(player, loop_status)
+            loop_status_cb(self, player, loop_status)
+        end
+        player.on_shuffle = function(player, shuffle_status)
+            shuffle_cb(self, player, shuffle_status)
+        end
+        player.on_exit = function(player, shuffle_status)
+            exit_cb(self, player)
+        end
+
+        -- Start position timer if its not already running
+        if not self._private.position_timer.started then
+            self._private.position_timer:again()
+        end
+    end
+end
+
+-- Determine if a player name comes before or after another according to the
+-- priority order
+local function player_compare_name(self, name_a, name_b)
+    local any_index = math.huge
+    local a_match_index = nil
+    local b_match_index = nil
+
+    if name_a == name_b then
+        return 0
+    end
+
+    for index, name in ipairs(self.priority) do
+        if name == "%any" then
+            any_index = (any_index == math.huge) and index or any_index
+        elseif name == name_a then
+            a_match_index = a_match_index or index
+        elseif name == name_b then
+            b_match_index = b_match_index or index
+        end
+    end
+
+    if not a_match_index and not b_match_index then
+        return 0
+    elseif not a_match_index then
+        return (b_match_index < any_index) and 1 or -1
+    elseif not b_match_index then
+        return (a_match_index < any_index) and -1 or 1
+    elseif a_match_index == b_match_index then
+        return 0
+    else
+        return (a_match_index < b_match_index) and -1 or 1
+    end
+end
+
+-- Sorting function used by manager if a priority order is specified
+local function player_compare(self, a, b)
+    local player_a = self._private.lgi_Playerctl.Player(a)
+    local player_b = self._private.lgi_Playerctl.Player(b)
+    return player_compare_name(self, player_a.player_name, player_b.player_name)
+end
+
+local function get_current_player_info(self, player)
+    local title = player:get_title() or ""
+    local artist = player:get_artist() or ""
+    local artUrl = player:print_metadata_prop("mpris:artUrl") or ""
+    local album = player:get_album() or ""
+
+    emit_metadata_signal(self, title, artist, artUrl, album, false, player.player_name)
+    playback_status_cb(self, player, player.playback_status)
+    volume_cb(self, player, player.volume)
+    loop_status_cb(self, player, player.loop_status)
+    shuffle_cb(self, player, player.shuffle)
+end
+
+local function start_manager(self)
+    self._private.manager = self._private.lgi_Playerctl.PlayerManager()
+
+    if #self.priority > 0 then
+        self._private.manager:set_sort_func(function(a, b)
+            return player_compare(self, a, b)
+        end)
+    end
+
+    -- Timer to update track position at specified interval
+    self._private.position_timer = gtimer {
+        timeout = self.interval,
+        callback = function()
+            position_cb(self)
+        end,
+    }
+
+    -- Manage existing players on startup
+    for _, name in ipairs(self._private.manager.player_names) do
+        init_player(self, name)
+    end
+
+    if self._private.manager.players[1] then
+        get_current_player_info(self, self._private.manager.players[1])
+    end
+
+    local _self = self
+
+    -- Callback to manage new players
+    function self._private.manager:on_name_appeared(name)
+        init_player(_self, name)
+    end
+
+    function self._private.manager:on_player_appeared(player)
+        if player == self.players[1] then
+            _self._private.active_player = player
+        end
+    end
+
+    function self._private.manager:on_player_vanished(player)
+        if #self.players == 0 then
+            _self._private.metadata_timer:stop()
+            _self._private.position_timer:stop()
+            _self:emit_signal("no_players")
+        elseif player == _self._private.active_player then
+            _self._private.active_player = self.players[1]
+            get_current_player_info(_self, self.players[1])
+        end
+    end
+end
+
+local function parse_args(self, args)
+    self.ignore = {}
+    if type(args.ignore) == "string" then
+        self.ignore[args.ignore] = true
+    elseif type(args.ignore) == "table" then
+        for _, name in pairs(args.ignore) do
+            self.ignore[name] = true
+        end
+    end
+
+    self.priority = {}
+    if type(args.player) == "string" then
+        self.priority[1] = args.player
+    elseif type(args.player) == "table" then
+        self.priority = args.player
+    end
+end
+
+local function new(args)
+    args = args or {}
+
+    local ret = gobject{}
+    gtable.crush(ret, playerctl, true)
+
+    -- Grab settings from beautiful variables if not set explicitly
+    args.ignore = args.ignore or beautiful.playerctl_ignore
+    args.player = args.player or beautiful.playerctl_player
+    ret.update_on_activity = args.update_on_activity or
+                              beautiful.playerctl_update_on_activity or true
+    ret.interval = args.interval or beautiful.playerctl_position_update_interval or 1
+    ret.debounce_delay = args.debounce_delay or beautiful.playerctl_debounce_delay or 0.35
+    parse_args(ret, args)
+
+    ret._private = {}
+
+    -- Metadata callback for title, artist, and album art
+    ret._private.last_player = nil
+    ret._private.last_title = ""
+    ret._private.last_artist = ""
+    ret._private.last_artUrl = ""
+
+    -- Track position callback
+    ret._private.last_position = -1
+    ret._private.last_length = -1
+
+    -- Grab playerctl library
+    ret._private.lgi_Playerctl = require("lgi").Playerctl
+    ret._private.manager = nil
+    ret._private.metadata_timer = nil
+    ret._private.position_timer = nil
+
+    -- Ensure main event loop has started before starting player manager
+    gtimer.delayed_call(function()
+        start_manager(ret)
+    end)
+
+    return ret
+end
+
+function playerctl.mt:__call(...)
+    return new(...)
+end
+
+return setmetatable(playerctl, playerctl.mt)


### PR DESCRIPTION
* ~~Made the Playerctl lib info persistent between AwesomeWM restarts to work around the fact that after a restarting a media could be playing but since there's no new metadata calls that info won't be available~~ 
What I did at c057bb42821f977dc953691d2a87b9e5082f180d was quite poor, after reading the Playerctl docs I found a much better way to handle that at 4164a7d2fc030d84f2518df37805dfadd90ccbab

* Added album parameter to the title_artist_album (it has album in the name after all)

* I noticed that some media with ampersand in their info would cause issues. I don't know why but '&amp' didn't work to escape them, so I replaced them with an empty character. Maybe this is something that should be done on the front-end though?

* Made the debounce delay customizable (defaults to 0.35 - maybe it should be 0?) as it can vary between different players. 

* Implement the Spotify art URL fix for the Playerctl CLI backend

* Fix for the following scenario:
1. Open up Player 1
2. Open up Player 2
3. Close Player 1
Player 1 info will still be the latest info available despite the fact Player 2 is now playing.

* Added methods to support managing playerctl with playerctl_lib