### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+trim_trailing_whitespace = true
+
+[*.lua]
+indent_size = 4
+indent_style = space
+
+[*.yml]
+indent_size = 2
+indent_style = space
+
+[*.{html,css}]
+indent_size = 2
+indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-        <img src="/images/bling_banner.png" />
+    <img src="/images/bling_banner.png" />
 </p>
 <h1 align="center"></h1>
 
@@ -36,12 +36,6 @@ In order to use the `tabbed` modules `pick` function, you need to install `xwini
 
 Contributions are welcome 💛
 
-When adding a module/layout/signal, please add theme variables for customization and add the according documentation under `docs`.
+Before requesting changes, makes sure that your editor have installed "editorconfig" extension, this will use our code style everytime when you enter `bling` folder.
 
-A special thanks to all our contributors...
-
-<a href="https://github.com/Nooo37/bling/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Nooo37/bling" />
-</a>
-
-Made with [contributors-img](https://contrib.rocks).
+When adding a layout/module/signal/widget, please add theme variables for customization and add the according documentation under `docs`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ In order to use the `tabbed` modules `pick` function, you need to install `xwini
 
 Contributions are welcome 💛
 
-Before requesting changes, makes sure that your editor have installed "editorconfig" extension, this will use our code style everytime when you enter `bling` folder.
+Before requesting changes, makes sure that your editor has an "editorconfig" extension installed, this will use our code style everytime when you edit in the `bling` folder.
 
 When adding a layout/module/signal/widget, please add theme variables for customization and add the according documentation under `docs`.


### PR DESCRIPTION
Every editor have built in support or simple extension for this `.editorconfig`, this little file automatically configure your editor for bling code style and re-configure to regular settings when you exit `bling` folder.

Also contributors img was removed from readme since you can see list of contributors on the right side.