### PR TITLE
[feat] Add support to wallpaper module for multiple screens

### DIFF
--- a/docs/module/wall.md
+++ b/docs/module/wall.md
@@ -49,10 +49,11 @@ bling.module.wallpaper.setup {
     change_timer = 600
 }
 
--- setup for all screens at once
+-- setup for multiple screens at once
+-- the 'screen' argument can be a table of screen objects
 bling.module.wallpaper.setup {
     set_function = bling.module.wallpaper.setters.random,
-    screens = screen, -- The awesome 'screen' variable is an array of all screen objects
+    screen = screen, -- The awesome 'screen' variable is an array of all screen objects
     wallpaper = {"/path/to/a/folder", "/path/to/another/folder"},
     change_timer = 631
 }
@@ -83,7 +84,8 @@ A wallpaper is one of the following elements:
 
 To set up for multiple screens, two possible methods are:
 * Call the `setup` function for each screen, passing the appropriate configuration and `screen` arg
-* Call the `setup` function once, passing an array of screens as the `screens` arg. This applies the same configuration to all screens
+* Call the `setup` function once, passing a table of screens as the `screen` arg. This applies the same configuration to all screens in the table
+_Note_: Multiple screen setup only works for the `simple` and `random` setters
 
 ```lua
 -- This is a valid wallpaper definition

--- a/docs/module/wall.md
+++ b/docs/module/wall.md
@@ -48,6 +48,14 @@ bling.module.wallpaper.setup {
     recursive = false,
     change_timer = 600
 }
+
+-- setup for all screens at once
+bling.module.wallpaper.setup {
+    set_function = bling.module.wallpaper.setters.random,
+    screens = screen, -- The awesome 'screen' variable is an array of all screen objects
+    wallpaper = {"/path/to/a/folder", "/path/to/another/folder"},
+    change_timer = 631
+}
 ```
 ### Details
 
@@ -72,6 +80,10 @@ A wallpaper is one of the following elements:
 * a function that sets a wallpaper
 * everything gears.wallpaper functions can manage (cairo surface, cairo pattern string)
 * a list containing any of the elements above
+
+To set up for multiple screens, two possible methods are:
+* Call the `setup` function for each screen, passing the appropriate configuration and `screen` arg
+* Call the `setup` function once, passing an array of screens as the `screens` arg. This applies the same configuration to all screens
 
 ```lua
 -- This is a valid wallpaper definition
@@ -100,6 +112,7 @@ Here are the defaults:
 -- Default parameters
 bling.module.wallpaper.setup {
     screen = nil,       -- the screen to apply the wallpaper, as seen in gears.wallpaper functions
+    screens = nil,      -- an array of screens to apply the wallpaper on. If 'screen' is also provided, this is overridden
     change_timer = nil, -- the timer in seconds. If set, call the set_function every change_timer seconds
     set_function = nil, -- the setter function
 

--- a/module/wallpaper.lua
+++ b/module/wallpaper.lua
@@ -53,36 +53,37 @@ function apply(wallpaper_object, args)
     args.offset = args.offset or { x = 0, y = 0 }
     args.scale = args.scale or 1
     local positions = {
-        ["centered"] = function()
+        ["centered"] = function(s)
             gears.wallpaper.centered(
                 wallpaper_object,
-                args.screen,
+                s,
                 args.background,
                 args.scale
             )
         end,
-        ["tiled"] = function()
-            gears.wallpaper.tiled(wallpaper_object, args.screen, args.offset)
+        ["tiled"] = function(s)
+            gears.wallpaper.tiled(wallpaper_object, s, args.offset)
         end,
-        ["maximized"] = function()
+        ["maximized"] = function(s)
             gears.wallpaper.maximized(
                 wallpaper_object,
-                args.screen,
+                s,
                 args.ignore_aspect,
                 args.offset
             )
         end,
-        ["fit"] = function()
-            gears.wallpaper.fit(wallpaper_object, args.screen, args.background)
+        ["fit"] = function(s)
+            gears.wallpaper.fit(wallpaper_object, s, args.background)
         end,
     }
+    local call_func = nil
     if
         type(wallpaper_object) == "string"
         and gears.filesystem.file_readable(wallpaper_object)
     then
         -- path of an image file, we use a position function
         local p = args.position or "centered"
-        positions[p]()
+        call_func = positions[p]
     elseif type(wallpaper_object) == "function" then
         -- function
         wallpaper_object(args)
@@ -91,9 +92,12 @@ function apply(wallpaper_object, args)
         and args.position
     then
         -- if the user sets a position function, wallpaper_object should be a cairo surface
-        positions[args.position]()
+        call_func = positions[args.position]
     else
         gears.wallpaper.set(wallpaper_object)
+    end
+    if call_func then
+        call_func(args.screen)
     end
 end
 
@@ -154,7 +158,15 @@ local simple_index = 0
 function setters.simple(args)
     local wallpapers = prepare_list(args)
     simple_index = (simple_index % #wallpapers) + 1
-    apply(wallpapers[simple_index], args)
+    if args.screens then
+        for _,v in ipairs(args.screens) do
+            args.screen = v
+            apply(wallpapers[simple_index], args)
+            args.screen = nil
+        end
+    else
+        apply(wallpapers[simple_index], args)
+    end
 end
 
 --- Set a random wallpaper from a list.
@@ -164,7 +176,15 @@ end
 -- @see prepare_list
 function setters.random(args)
     local wallpapers = prepare_list(args)
-    apply(wallpapers[math.random(#wallpapers)], args)
+    if args.screens then
+        for _,v in ipairs(args.screens) do
+            args.screen = v
+            apply(wallpapers[math.random(#wallpapers)], args)
+            args.screen = nil
+        end
+    else
+        apply(wallpapers[math.random(#wallpapers)], args)
+    end
 end
 
 local simple_schedule_object = nil
@@ -310,7 +330,10 @@ function setup(args)
     config.set_function = config.set_function
         or (config.wallpaper and setters.simple or setters.awesome_wallpaper)
     local function set_wallpaper(s)
-        config.screen = s or config.screen
+        if config.screen and s and config.screen ~= s then return end
+        if not config.screens then
+            config.screen = s or config.screen
+        end
         config.set_function(config)
     end
 

--- a/module/wallpaper.lua
+++ b/module/wallpaper.lua
@@ -159,7 +159,7 @@ function setters.simple(args)
     local wallpapers = prepare_list(args)
     simple_index = (simple_index % #wallpapers) + 1
     if type(args.screen) == 'table' then
-        for _,v in ipairs(args.screens) do
+        for _,v in ipairs(args.screen) do
             args.screen = v
             apply(wallpapers[simple_index], args)
             args.screen = nil
@@ -177,7 +177,7 @@ end
 function setters.random(args)
     local wallpapers = prepare_list(args)
     if type(args.screen) == 'table' then
-        for _,v in ipairs(args.screens) do
+        for _,v in ipairs(args.screen) do
             args.screen = v
             apply(wallpapers[math.random(#wallpapers)], args)
             args.screen = nil
@@ -330,8 +330,7 @@ function setup(args)
     config.set_function = config.set_function
         or (config.wallpaper and setters.simple or setters.awesome_wallpaper)
     local function set_wallpaper(s)
-        if type(config.screen) == 'table' then
-        else
+        if type(config.screen) ~= 'table' then
             if config.screen and s and config.screen ~= s then return end
             config.screen = s or config.screen
         end

--- a/module/wallpaper.lua
+++ b/module/wallpaper.lua
@@ -158,7 +158,7 @@ local simple_index = 0
 function setters.simple(args)
     local wallpapers = prepare_list(args)
     simple_index = (simple_index % #wallpapers) + 1
-    if args.screens then
+    if type(args.screen) == 'table' then
         for _,v in ipairs(args.screens) do
             args.screen = v
             apply(wallpapers[simple_index], args)
@@ -176,7 +176,7 @@ end
 -- @see prepare_list
 function setters.random(args)
     local wallpapers = prepare_list(args)
-    if args.screens then
+    if type(args.screen) == 'table' then
         for _,v in ipairs(args.screens) do
             args.screen = v
             apply(wallpapers[math.random(#wallpapers)], args)
@@ -330,8 +330,9 @@ function setup(args)
     config.set_function = config.set_function
         or (config.wallpaper and setters.simple or setters.awesome_wallpaper)
     local function set_wallpaper(s)
-        if config.screen and s and config.screen ~= s then return end
-        if not config.screens then
+        if type(config.screen) == 'table' then
+        else
+            if config.screen and s and config.screen ~= s then return end
             config.screen = s or config.screen
         end
         config.set_function(config)


### PR DESCRIPTION
This PR adds support to the wallpaper module for multiple screens. It introduces the following changes -
1. Calling `setup` multiple times with different `screen` arguments works correctly
2. A new `screens` argument to the setup function, which allows setup of multiple screens by passing a table of screens. Currently only supports the simple and random pickers
