### PR TITLE
Added new feature for tag_preview widget

### DIFF
--- a/docs/widgets/tag_preview.md
+++ b/docs/widgets/tag_preview.md
@@ -25,7 +25,13 @@ bling.widget.tag_preview.enable {
                 left = 30
             }
         })
-    end
+    end,
+	background_image = wibox.widget {	-- Set a background image (like a wallpaper) for the widget 
+        image = beautiful.wallpaper,
+        horizontal_fit_policy = "fit",
+        vertical_fit_policy   = "fit",
+        widget = wibox.widget.imagebox
+    }
 }
 ```
 

--- a/widget/tag_preview.lua
+++ b/widget/tag_preview.lua
@@ -28,7 +28,8 @@ local function draw_widget(
     widget_border_color,
     widget_border_width,
     geo,
-    margin
+    margin,
+    background_image
 )
     local client_list = wibox.layout.manual()
     client_list.forced_height = geo.height
@@ -109,20 +110,24 @@ local function draw_widget(
 
     return wibox.widget {
         {
+            background_image,
             {
                 {
                     {
-                        client_list,
-                        forced_height = geo.height,
-                        forced_width = geo.width,
-                        widget = wibox.container.place,
+                        {
+                            client_list,
+                            forced_height = geo.height,
+                            forced_width = geo.width,
+                            widget = wibox.container.place,
+                        },
+                        layout = wibox.layout.align.horizontal,
                     },
-                    layout = wibox.layout.align.horizontal,
+                    layout = wibox.layout.align.vertical,
                 },
-                layout = wibox.layout.align.vertical,
+                margins = margin,
+                widget = wibox.container.margin,
             },
-            margins = margin,
-            widget = wibox.container.margin,
+            layout = wibox.layout.stack
         },
         bg = widget_bg,
         shape_border_width = widget_border_width,
@@ -142,6 +147,7 @@ local enable = function(opts)
     local work_area = opts.honor_workarea or false
     local padding = opts.honor_padding or false
     local placement_fn = opts.placement_fn or nil
+    local background_image = opts.background_image or nil
 
     local margin = beautiful.tag_preview_widget_margin or dpi(0)
     local screen_radius = beautiful.tag_preview_widget_border_radius or dpi(0)
@@ -196,7 +202,8 @@ local enable = function(opts)
             widget_border_color,
             widget_border_width,
             geo,
-            margin
+            margin,
+            background_image
         )
     end)
 


### PR DESCRIPTION
The tag preview widgets can have a wallpaper background.

![Untitled](https://user-images.githubusercontent.com/33443763/138656042-5f0f180f-1997-4d21-bcea-63205425c61e.png)

Sample:

```lua
bling.widget.tag_preview.enable {
    show_client_content = false,
    scale = 0.15,
    honor_padding = true,
    honor_workarea = false,
    background_image = wibox.widget  {
        image = beautiful.wallpaper,
        horizontal_fit_policy = "fit",
        vertical_fit_policy   = "fit",
        widget = wibox.widget.imagebox
    }
}
```

