### PR TITLE
Fix some issue with the client preview for the tag and task preview widgets

### DIFF
--- a/widget/tag_preview.lua
+++ b/widget/tag_preview.lua
@@ -175,9 +175,22 @@ local enable = function(opts)
     })
 
     tag.connect_signal("property::selected", function(t)
-        for _, c in ipairs(t:clients()) do
-            c.prev_content = gears.surface.duplicate_surface(c.content)
-        end
+        -- Awesome switches up tags on startup really fast it seems, probably depends on what rules you have set
+        -- which can cause the c.content to not show the correct image
+        gears.timer
+        {
+            timeout = 0.1,
+            call_now  = false,
+            autostart = true,
+            single_shot = true,
+            callback = function()
+                if t.selected == true then
+                    for _, c in ipairs(t:clients()) do
+                        c.prev_content = gears.surface.duplicate_surface(c.content)
+                    end
+                end
+            end
+        }
     end)
 
     awesome.connect_signal("bling::tag_preview::update", function(t)

--- a/widget/task_preview.lua
+++ b/widget/task_preview.lua
@@ -30,14 +30,24 @@ local function draw_widget(
     end) then
         return
     end
-    local content = gears.surface(c.content)
-    local cr = cairo.Context(content)
-    local x, y, w, h = cr:clip_extents()
-    local img = cairo.ImageSurface.create(cairo.Format.ARGB32, w - x, h - y)
-    cr = cairo.Context(img)
-    cr:set_source_surface(content, 0, 0)
-    cr.operator = cairo.Operator.SOURCE
-    cr:paint()
+
+    local content = nil
+    if c.active then
+        content = gears.surface(c.content)
+    elseif c.prev_content then
+        content = gears.surface(c.prev_content)
+    end
+
+    local img = nil
+    if content ~= nil then
+        local cr = cairo.Context(content)
+        local x, y, w, h = cr:clip_extents()
+        img = cairo.ImageSurface.create(cairo.Format.ARGB32, w - x, h - y)
+        cr = cairo.Context(img)
+        cr:set_source_surface(content, 0, 0)
+        cr.operator = cairo.Operator.SOURCE
+        cr:paint()
+    end
 
     local widget = wibox.widget({
         (widget_template or {
@@ -138,6 +148,25 @@ local enable = function(opts)
         input_passthrough = true,
         bg = "#00000000",
     })
+
+    tag.connect_signal("property::selected", function(t)
+        -- Awesome switches up tags on startup really fast it seems, probably depends on what rules you have set
+        -- which can cause the c.content to not show the correct image
+        gears.timer
+        {
+            timeout = 0.1,
+            call_now  = false,
+            autostart = true,
+            single_shot = true,
+            callback = function()
+                if t.selected == true then
+                    for _, c in ipairs(t:clients()) do
+                        c.prev_content = gears.surface.duplicate_surface(c.content)
+                    end
+                end
+            end
+        }
+    end)
 
     awesome.connect_signal("bling::task_preview::visibility", function(s, v, c)
         if v then


### PR DESCRIPTION
@JavaCafe01 

Some other issues:

1. I think these widgets should be turned into proper objects, with methods like :show() :hide() and :toggle() instead of the current signals. 
2. When there isn't an available client.content to preview, the tag preview displays a black background with the client icon in the cener. The task preview before this PR would always show the client.content, so there wasn't a need for that - but maybe we should at now do it here too?
3. The task preview height differes between clients. I think it has to be with the title not being limited in size?
4.  What about using #129 to the get the icons for the running clients? It will retrive the icon for the running client from the currently system selected icon theme, or whatever theme was passed to the constructor 