### PR TITLE
[2/3] Cleanup argument parsing for some widgets + refactor of window switcher

### DIFF
--- a/docs/widgets/task_preview.md
+++ b/docs/widgets/task_preview.md
@@ -41,12 +41,12 @@ bling.widget.task_preview.enable {
         }) 
     end,
     -- Your widget will automatically conform to the given size due to a constraint container.
-    widget_structure = {
+    widget_template = {
         {
             {
                 {
                     id = 'icon_role', 
-                    widget = awful.widget.clienticon, -- The client icon
+                    widget = awful.widget.clienticon, -- The client icon, this can be a clienticon or a imagebox
                 },
                 {
                     id = 'name_role' -- The client name / title
@@ -58,7 +58,7 @@ bling.widget.task_preview.enable {
             margins = 5
         },
         {
-            id = 'image_role', -- The client preview
+            id = 'image_role', -- The client preview, must be a imagebox
             resize = true,
             valign = 'center',
             halign = 'center'

--- a/helpers/init.lua
+++ b/helpers/init.lua
@@ -4,4 +4,5 @@ return {
     filesystem = require(... .. ".filesystem"),
     shape = require(... .. ".shape"),
     time = require(... .. ".time"),
+	util = require(... .. ".util")
 }

--- a/helpers/util.lua
+++ b/helpers/util.lua
@@ -1,0 +1,40 @@
+-- TODO: This is definatley in the wrong place.
+local beautiful = require("beautiful")
+local gears = require("gears")
+local M = {}
+
+function M.retrieveArguments(original, fromArgs)
+	local fromTheme = {}
+	-- TODO: make this into one table?
+	local moduleName = original[1]
+
+	if not moduleName then
+		error("No module name given, is required...")
+	end
+
+	local ignoreFromTheme = original[2] or {}
+	fromArgs = fromArgs or {}
+
+	-- This is for some of my things that dont use the whole prefix thing,
+	-- instead they just use a table
+	-- TODO: Skip collection from beautiful for certain things as it might become a bit of a mess
+	if type(beautiful[moduleName]) == "table" then
+		fromTheme = beautiful[moduleName]
+		goto skipThemeCollection
+	end
+
+	for key, _ in pairs(original) do
+		if gears.table.hasitem(ignoreFromTheme, key) ~= nil then
+			goto continue
+		end
+		fromTheme[key] = beautiful[moduleName .. "_" .. key] 
+		::continue::
+	end
+
+	::skipThemeCollection::
+
+	-- Importance: Args > Theme > Default
+	return gears.table.crush(original, gears.table.crush(fromTheme, fromArgs))
+end
+
+return M

--- a/helpers/util.lua
+++ b/helpers/util.lua
@@ -3,9 +3,25 @@ local beautiful = require("beautiful")
 local gears = require("gears")
 local M = {}
 
+--[[ Example
+function (args)
+  local helpers = require(tostring(...):match(".*bling") .. ".helpers")
+  local options = helpers.util.retrieveArguments({
+  	"<Module Name>"
+  	{ "other" },
+  	color = "#fff",
+  	other = "aaa"
+  }, args)
+  end
+]]--
+
+
+-- [TODO] Allow certain arguments to be generated within the context of other arguments
+-- [TODO] Type check arguments as much as possible
+-- [TODO] Allow `ignoreFromTheme' to be a pattern
 function M.retrieveArguments(original, fromArgs)
 	local fromTheme = {}
-	-- TODO: make this into one table?
+	-- [TODO] make this into one table?
 	local moduleName = original[1]
 
 	if not moduleName then
@@ -17,22 +33,28 @@ function M.retrieveArguments(original, fromArgs)
 
 	-- This is for some of my things that dont use the whole prefix thing,
 	-- instead they just use a table
-	-- TODO: Skip collection from beautiful for certain things as it might become a bit of a mess
+	-- [TODO]: Skip collection from beautiful for certain things as it might become a bit of a mess
 	if type(beautiful[moduleName]) == "table" then
 		fromTheme = beautiful[moduleName]
-		goto skipThemeCollection
-	end
+	else
 
+	local to_be_ignored = function(it)
+	  return gears.table.hasitem(ignoreFromTheme, it) ~= nil
+	end
+	if (type(ignoreFromTheme) == "string") then
+	  to_be_ignored = function(it) return string.find(it, ignoreFromTheme) ~= nil end
+	end
+	
 	for key, _ in pairs(original) do
-		if gears.table.hasitem(ignoreFromTheme, key) ~= nil then
+	  if to_be_ignored(key) then
 			goto continue
 		end
 		fromTheme[key] = beautiful[moduleName .. "_" .. key] 
 		::continue::
 	end
 
-	::skipThemeCollection::
-
+	end
+	
 	-- Importance: Args > Theme > Default
 	return gears.table.crush(original, gears.table.crush(fromTheme, fromArgs))
 end

--- a/widget/tabbed_misc/titlebar_indicator.lua
+++ b/widget/tabbed_misc/titlebar_indicator.lua
@@ -3,9 +3,13 @@ local awful = require("awful")
 local gears = require("gears")
 local beautiful = require("beautiful")
 local dpi = require("beautiful.xresources").apply_dpi
+
 local tabbed_module = require(
     tostring(...):match(".*bling") .. ".module.tabbed"
 )
+
+local tabbed_module = require(tostring(...):match(".*bling") .. ".module.tabbed")
+local helpers = require(tostring(...):match(".*bling") .. ".helpers")
 
 -- Just check if a table contains a value.
 local function tbl_contains(tbl, item)
@@ -19,100 +23,113 @@ end
 
 -- Needs to be run, every time a new titlbear is created
 return function(c, opts)
-    -- Args & Fallback -- Widget templates are in their original loactions
-    opts = gears.table.crush({
-        layout_spacing = dpi(4),
-        icon_size = dpi(20),
-        icon_margin = dpi(4),
-        bg_color_focus = "#ff0000",
-        bg_color = "#00000000",
-        icon_shape = function(cr, w, h)
-            gears.shape.rounded_rect(cr, w, h, 0)
-        end,
-    }, gears.table.join(
-        opts,
-        beautiful.bling_tabbed_misc_titlebar_indicator
-    ))
+	-- Args & Fallback -- Widget templates are in their original loactions
+	opts = helpers.util.retrieveArguments({
+		"bling_tabbed_misc_titlebar_indicator",
+		layout_spacing = dpi(4),
+		icon_size = dpi(20),
+		icon_margin = dpi(4),
+		bg_color_focus = "#ff0000",
+		bg_color = "#00000000",
+		fg_color = "#fafafa",
+		fg_color_focus = "#e0e0e0",
+		icon_shape = function(cr, w, h)
+			gears.shape.rounded_rect(cr, w, h, 0)
+		end,
+		layout = wibox.layout.fixed.horizontal
+	}, opts)
 
-    -- Container to store icons
-    local tabbed_icons = wibox.widget({
-        layout = wibox.layout.fixed.horizontal,
-        spacing = opts.layout_spacing,
-    })
+	-- Container to store icons
+	local tabbed_icons = wibox.widget({
+		layout = opts.layout,
+		spacing = opts.layout_spacing,
+	})
 
-    awesome.connect_signal(
-        "bling::tabbed::client_removed",
-        function(_, removed_c)
-            -- Remove from list
-            for idx, icon in ipairs(tabbed_icons.children) do
-                if
-                    icon:get_children_by_id("icon_role")[1].client == removed_c
-                then
-                    tabbed_icons:remove(idx)
-                end
-            end
+	awesome.connect_signal("bling::tabbed::client_removed", function(_, removed_c)
+		-- Remove from list
+		for idx, icon in ipairs(tabbed_icons.children) do
+			if icon._client == removed_c then
+				tabbed_icons:remove(idx)
+			end
+		end
 
-            -- Empty list
-            if removed_c == c then
-                tabbed_icons:reset()
-            end
-        end
-    )
+		-- Empty list
+		if removed_c == c then
+			tabbed_icons:reset()
+		end
+	end)
 
-    local function recreate(group)
-        if tbl_contains(group.clients, c) then
-            tabbed_icons:reset()
-            local focused = group.clients[group.focused_idx]
+	local function recreate(group)
+		if tbl_contains(group.clients, c) then
+			tabbed_icons:reset()
+			local focused = group.clients[group.focused_idx]
 
-            -- Autohide?
-            if #group.clients == 1 then
-                return
-            end
+			-- Autohide?
+			if #group.clients == 1 then
+				return
+			end
 
-            for idx, client in ipairs(group.clients) do
-                local widget = wibox.widget(opts.widget_template or {
-                    {
-                        {
-                            {
-                                id = "icon_role",
-                                forced_width = opts.icon_size,
-                                forced_height = opts.icon_size,
-                                widget = awful.widget.clienticon,
-                            },
-                            margins = opts.icon_margin,
-                            widget = wibox.container.margin,
-                        },
-                        bg = (client == focused) and opts.bg_color_focus
-                            or opts.bg_color,
-                        shape = opts.icon_shape,
-                        id = "click_role",
-                        widget = wibox.container.background,
-                    },
-                    halign = "center",
-                    valign = "center",
-                    widget = wibox.container.place,
-                })
+			for idx, client in ipairs(group.clients) do
+				local widget = wibox.widget(
+					opts.widget_template or {
+					{
+						{
+							{
+								id = "icon_role",
+								forced_width = opts.icon_size,
+								forced_height = opts.icon_size,
+								widget = awful.widget.clienticon,
+							},
+							margins = opts.icon_margin,
+							widget = wibox.container.margin,
+						},
+						shape = opts.icon_shape,
+						id = "bg_role",
+						widget = wibox.container.background,
+					},
+					halign = "center",
+					valign = "center",
+					widget = wibox.container.place,
+				})
 
-                -- Add icons & etc
-                for _, w in ipairs(widget:get_children_by_id("icon_role")) do
-                    -- TODO: Allow fallback icon?
-                    w.image = client.icon
-                    w.client = client
-                end
+				widget._client = client
 
-                for _, w in ipairs(widget:get_children_by_id("click_role")) do
-                    w:add_button(awful.button({}, 1, function()
-                        tabbed_module.switch_to(group, idx)
-                    end))
-                end
+				-- No creation call back since this would be called on creation & every time the widget updated.
+				if opts.widget_template and opts.widget_template.update_callback then
+					opts.widget_template.update_callback(widget, client, group)
+				end
 
-                tabbed_icons:add(widget)
-            end
-        end
-    end
+				-- Add icons & etc
+				for _, w in ipairs(widget:get_children_by_id("icon_role")) do
+					-- TODO: Allow fallback icon?
+					w.image = client.icon
+					w.client = client
+				end
 
-    awesome.connect_signal("bling::tabbed::client_added", recreate)
-    awesome.connect_signal("bling::tabbed::changed_focus", recreate)
+				for _, w in ipairs(widget:get_children_by_id("bg_role")) do
+					w:add_button(awful.button({}, 1, function()
+						tabbed_module.switch_to(group, idx)
+					end))
+					if client == focused then
+						w.bg = opts.bg_color_focus
+						w.fg = opts.fg_color_focus
+					else
+						w.bg = opts.bg_color
+						w.fg = opts.fg_color
+					end
+				end
 
-    return tabbed_icons
+				for _, w in ipairs(widget:get_children_by_id("text_role")) do
+					w.text = client.name
+				end
+
+				tabbed_icons:add(widget)
+			end
+		end
+	end
+
+	awesome.connect_signal("bling::tabbed::client_added", recreate)
+	awesome.connect_signal("bling::tabbed::changed_focus", recreate)
+
+	return tabbed_icons
 end

--- a/widget/tag_preview.lua
+++ b/widget/tag_preview.lua
@@ -14,202 +14,184 @@ local beautiful = require("beautiful")
 local dpi = beautiful.xresources.apply_dpi
 local cairo = require("lgi").cairo
 
-local function draw_widget(
-    t,
-    tag_preview_image,
-    scale,
-    screen_radius,
-    client_radius,
-    client_opacity,
-    client_bg,
-    client_border_color,
-    client_border_width,
-    widget_bg,
-    widget_border_color,
-    widget_border_width,
-    geo,
-    margin
-)
-    local client_list = wibox.layout.manual()
-    client_list.forced_height = geo.height
-    client_list.forced_width = geo.width
-    local tag_screen = t.screen
-    for i, c in ipairs(t:clients()) do
-        if not c.hidden and not c.minimized then
-            local img_box = wibox.widget({
-                image = gears.surface.load(c.icon),
-                resize = true,
-                forced_height = 100 * scale,
-                forced_width = 100 * scale,
-                widget = wibox.widget.imagebox,
-            })
 
-            if tag_preview_image then
-                if c.prev_content or t.selected then
-                    local content
-                    if t.selected then
-                        content = gears.surface(c.content)
-                    else
-                        content = gears.surface(c.prev_content)
-                    end
-                    local cr = cairo.Context(content)
-                    local x, y, w, h = cr:clip_extents()
-                    local img = cairo.ImageSurface.create(
-                        cairo.Format.ARGB32,
-                        w - x,
-                        h - y
-                    )
-                    cr = cairo.Context(img)
-                    cr:set_source_surface(content, 0, 0)
-                    cr.operator = cairo.Operator.SOURCE
-                    cr:paint()
+local function draw_widget(t, o, geo)
 
-                    img_box = wibox.widget({
-                        image = gears.surface.load(img),
-                        resize = true,
-                        opacity = client_opacity,
-                        forced_height = math.floor(c.height * scale),
-                        forced_width = math.floor(c.width * scale),
-                        widget = wibox.widget.imagebox,
-                    })
-                end
-            end
+		local client_list = wibox.layout.manual()
+		client_list.forced_height = geo.height
+		client_list.forced_width = geo.width
+		local tag_screen = t.screen
+		for i, c in ipairs(t:clients()) do
+			if not c.hidden and not c.minimized then
+				local img_box = wibox.widget({
+					image = gears.surface.load(c.icon),
+					resize = true,
+					forced_height = 100 * o.scale,
+					forced_width = 100 * o.scale,
+					widget = wibox.widget.imagebox
+				})
 
-            local client_box = wibox.widget({
-                {
-                    nil,
-                    {
-                        nil,
-                        img_box,
-                        nil,
-                        expand = "outside",
-                        layout = wibox.layout.align.horizontal,
-                    },
-                    nil,
-                    expand = "outside",
-                    widget = wibox.layout.align.vertical,
-                },
-                forced_height = math.floor(c.height * scale),
-                forced_width = math.floor(c.width * scale),
-                bg = client_bg,
-                shape_border_color = client_border_color,
-                shape_border_width = client_border_width,
-                shape = helpers.shape.rrect(client_radius),
-                widget = wibox.container.background,
-            })
+				-- If fails to set image, fallback to a awesome icon
+				if not pcall(function() img_box.image = gears.surface.load(c.icon) end) then
+				img_box.image = beautiful.theme_assets.awesome_icon (24, "#222222", "#fafafa")
+			end
 
-            client_box.point = {
-                x = math.floor((c.x - geo.x) * scale),
-                y = math.floor((c.y - geo.y) * scale),
-            }
+			if o.show_client_content then
+				if c.prev_content or t.selected then
+					local content
+					if t.selected then
+						content = gears.surface(c.content)
+					else
+						content = gears.surface(c.prev_content)
+					end
+					local cr = cairo.Context(content)
+					local x, y, w, h = cr:clip_extents()
+					local img = cairo.ImageSurface.create(
+					cairo.Format.ARGB32,
+					w - x,
+					h - y
+					)
+					cr = cairo.Context(img)
+					cr:set_source_surface(content, 0, 0)
+					cr.operator = cairo.Operator.SOURCE
+					cr:paint()
 
-            client_list:add(client_box)
-        end
-    end
+					img_box = wibox.widget({
+						image = gears.surface.load(img),
+						resize = true,
+						opacity = o.client_opacity,
+						forced_height = math.floor(c.height * o.scale),
+						forced_width = math.floor(c.width * o.scale),
+						widget = wibox.widget.imagebox
+					})
+				end
+			end
 
-    return {
-        {
-            {
-                {
-                    {
-                        client_list,
-                        forced_height = geo.height,
-                        forced_width = geo.width,
-                        widget = wibox.container.place,
-                    },
-                    layout = wibox.layout.align.horizontal,
-                },
-                layout = wibox.layout.align.vertical,
-            },
-            margins = margin,
-            widget = wibox.container.margin,
-        },
-        bg = widget_bg,
-        shape_border_width = widget_border_width,
-        shape_border_color = widget_border_color,
-        shape = helpers.shape.rrect(screen_radius),
-        widget = wibox.container.background,
-    }
+			local client_box = wibox.widget({
+				{
+					nil,
+					{
+						nil,
+						img_box,
+						nil,
+						expand = "outside",
+						layout = wibox.layout.align.horizontal,
+					},
+					nil,
+					expand = "outside",
+					widget = wibox.layout.align.vertical,
+				},
+				forced_height = math.floor(c.height * o.scale),
+				forced_width = math.floor(c.width * o.scale),
+				bg = o.client_bg,
+				shape_border_color = o.client_border_color,
+				shape_border_width = o.client_border_width,
+				shape = helpers.shape.rrect(o.client_border_radius),
+				widget = wibox.container.background
+			})
+
+			client_box.point = {
+				x = math.floor((c.x - geo.x) * o.scale),
+				y = math.floor((c.y - geo.y) * o.scale)
+			}
+
+			client_list:add(client_box)
+		end
+	end
+
+	return {
+		{
+			{
+				{
+					{
+						client_list,
+						forced_height = geo.height,
+						forced_width = geo.width,
+						widget = wibox.container.place,
+					},
+					layout = wibox.layout.align.horizontal,
+				},
+				layout = wibox.layout.align.vertical,
+			},
+			margins = o.widget_margin,
+			widget = wibox.container.margin
+
+		},
+		bg = o.widget_bg,
+		shape_border_width = o.widget_border_width,
+		shape_border_color = o.widget_border_color,
+		shape = helpers.shape.rrect(o.screen_border_radius),
+		widget = wibox.container.background
+	}
 end
 
 local enable = function(opts)
-    local opts = opts or {}
 
-    local tag_preview_image = opts.show_client_content or false
-    local widget_x = opts.x or dpi(20)
-    local widget_y = opts.y or dpi(20)
-    local scale = opts.scale or 0.2
-    local work_area = opts.honor_workarea or false
-    local padding = opts.honor_padding or false
-    local placement_fn = opts.placement_fn or nil
 
-    local margin = beautiful.tag_preview_widget_margin or dpi(0)
-    local screen_radius = beautiful.tag_preview_widget_border_radius or dpi(0)
-    local client_radius = beautiful.tag_preview_client_border_radius or dpi(0)
-    local client_opacity = beautiful.tag_preview_client_opacity or 0.5
-    local client_bg = beautiful.tag_preview_client_bg or "#000000"
-    local client_border_color = beautiful.tag_preview_client_border_color
-        or "#ffffff"
-    local client_border_width = beautiful.tag_preview_client_border_width
-        or dpi(3)
-    local widget_bg = beautiful.tag_preview_widget_bg or "#000000"
-    local widget_border_color = beautiful.tag_preview_widget_border_color
-        or "#ffffff"
-    local widget_border_width = beautiful.tag_preview_widget_border_width
-        or dpi(3)
+	-- TODO:
+	-- For the backgrounds, somehow detect if they are a image!
+	-- and use bgimage
+	--
+	-- NOTE: I think I might have changed some names here,
+	-- If so I need to change them to fit the current api.
+	opts = helpers.util.retrieveArguments({
+		"tag_preview", -- Module name
+		{ "show_client_content", "x", "y", "scale", "honor_workarea", "honor_padding", "placement_fn" }, -- ignore from theme
+		show_client_content = false,
+		x = dpi(20),
+		y = dpi(20),
+		scale = 0.2,
+		honor_workarea = false,
+		honor_padding = false,
+		placement_fn = nil,
 
-    local tag_preview_box = awful.popup({
-        type = "dropdown_menu",
-        visible = false,
-        ontop = true,
-        placement = placement_fn,
-        widget = wibox.container.background,
-        input_passthrough = true,
-        bg = "#00000000",
-    })
+		widget_margin = dpi(0),
+		widget_border_radius = dpi(0),
+		client_border_radius = dpi(0),
+		client_opacity = 0.5,
+		client_bg = "#000000",
+		client_border_color = "#ffffff",
+		client_border_width = dpi(3),
+		widget_bg = "#000000",
+		widget_border_color = "#ffffff",
+		widget_border_width = dpi(3)
+	}, opts) 
 
-    tag.connect_signal("property::selected", function(t)
-        for _, c in ipairs(t:clients()) do
-            c.prev_content = gears.surface.duplicate_surface(c.content)
-        end
-    end)
+	local tag_preview_box = awful.popup({
+		type = "dropdown_menu",
+		visible = false,
+		ontop = true,
+		placement = opts.placement_fn,
+		widget = wibox.container.background,
+		input_passthrough = true,
+		bg = "#00000000",
+	})
 
-    awesome.connect_signal("bling::tag_preview::update", function(t)
-        local geo = t.screen:get_bounding_geometry({
-            honor_padding = padding,
-            honor_workarea = work_area,
-        })
+	tag.connect_signal("property::selected", function(t)
+		for _, c in ipairs(t:clients()) do
+			c.prev_content = gears.surface.duplicate_surface(c.content)
+		end
+	end)
 
-        tag_preview_box.maximum_width = scale * geo.width + margin * 2
-        tag_preview_box.maximum_height = scale * geo.height + margin * 2
-        tag_preview_box:setup(
-            draw_widget(
-                t,
-                tag_preview_image,
-                scale,
-                screen_radius,
-                client_radius,
-                client_opacity,
-                client_bg,
-                client_border_color,
-                client_border_width,
-                widget_bg,
-                widget_border_color,
-                widget_border_width,
-                geo,
-                margin
-            )
-        )
-    end)
+	awesome.connect_signal("bling::tag_preview::update", function(t)
+		local geo = t.screen:get_bounding_geometry{
+			honor_padding = opts.honor_padding,
+			honor_workarea = opts.honor_work_area
+		}
 
-    awesome.connect_signal("bling::tag_preview::visibility", function(s, v)
-        if not placement_fn then
-            tag_preview_box.x = s.geometry.x + widget_x
-            tag_preview_box.y = s.geometry.y + widget_y
-        end
+		tag_preview_box.maximum_width = scale * geo.width + margin * 2
+		tag_preview_box.maximum_height = scale * geo.height + margin * 2
+		tag_preview_box:setup(draw_widget(tag, opts, margin))
+	end)
 
-        tag_preview_box.visible = v
-    end)
+	awesome.connect_signal("bling::tag_preview::visibility", function(s, v)
+		if not placement_fn then
+			tag_preview_box.x = s.geometry.x + opts.x
+			tag_preview_box.y = s.geometry.y + opts.y
+		end
+
+		tag_preview_box.visible = v
+	end)
 end
 
 return { enable = enable }

--- a/widget/task_preview.lua
+++ b/widget/task_preview.lua
@@ -17,6 +17,7 @@ local cairo = require("lgi").cairo
 local function draw_widget(
     c,
     opts)
+  
     if not pcall(function()
         return type(c.content)
     end) then
@@ -112,14 +113,15 @@ local enable = function(opts)
 		y = dpi(20),
 		height = dpi(200),
 		width = dpi(200),
-
+		margin = dpi(1),
+		
 		placement_fn = nil,
 		widget_margin = dpi(0),
 		widget_border_radius = dpi(0),
 		widget_bg = "#000000",
 		widget_border_color = "#ffffff",
 		widget_border_width = dpi(3)
-	}, opts)
+}, opts)
 
     local task_preview_box = awful.popup({
         type = "dropdown_menu",
@@ -149,4 +151,4 @@ local enable = function(opts)
     end)
 end
 
-return { enable = enable }
+return { enable = enable, draw_widget = draw_widget}

--- a/widget/task_preview.lua
+++ b/widget/task_preview.lua
@@ -16,15 +16,7 @@ local cairo = require("lgi").cairo
 -- TODO: rename structure to something better?
 local function draw_widget(
     c,
-    widget_template,
-    screen_radius,
-    widget_bg,
-    widget_border_color,
-    widget_border_width,
-    margin,
-    widget_width,
-    widget_height
-)
+    opts)
     if not pcall(function()
         return type(c.content)
     end) then
@@ -40,7 +32,7 @@ local function draw_widget(
     cr:paint()
 
     local widget = wibox.widget({
-        (widget_template or {
+        (opts.widget_template or {
             {
                 {
                     {
@@ -68,30 +60,30 @@ local function draw_widget(
                             {
                                 id = "image_role",
                                 resize = true,
-                                clip_shape = helpers.shape.rrect(screen_radius),
+                                clip_shape = helpers.shape.rrect(opts.widget_border_radius),
                                 widget = wibox.widget.imagebox,
                             },
                             valign = "center",
                             halign = "center",
                             widget = wibox.container.place,
                         },
-                        top = margin * 0.25,
+                        top = opts.margin * 0.25,
                         widget = wibox.container.margin,
                     },
                     fill_space = true,
                     layout = wibox.layout.fixed.vertical,
                 },
-                margins = margin,
+                margins = opts.margin,
                 widget = wibox.container.margin,
             },
-            bg = widget_bg,
-            shape_border_width = widget_border_width,
-            shape_border_color = widget_border_color,
-            shape = helpers.shape.rrect(screen_radius),
+            bg = opts.widget_bg,
+            shape_border_width = opts.widget_border_width,
+            shape_border_color = opts.widget_border_color,
+            shape = helpers.shape.rrect(opts.widget_border_radius),
             widget = wibox.container.background,
         }),
-        width = widget_width,
-        height = widget_height,
+        width = opts.widget_width,
+        height = opts.widget_height,
         widget = wibox.container.constraint,
     })
 
@@ -113,27 +105,27 @@ local function draw_widget(
 end
 
 local enable = function(opts)
-    local opts = opts or {}
+    local opts = helpers.util.retrieveArguments({
+		"task_preview",
+		{ "x" , "y", "height", "width", "placement_fn" },
+		x = dpi(20),
+		y = dpi(20),
+		height = dpi(200),
+		width = dpi(200),
 
-    local widget_x = opts.x or dpi(20)
-    local widget_y = opts.y or dpi(20)
-    local widget_height = opts.height or dpi(200)
-    local widget_width = opts.width or dpi(200)
-    local placement_fn = opts.placement_fn or nil
-
-    local margin = beautiful.task_preview_widget_margin or dpi(0)
-    local screen_radius = beautiful.task_preview_widget_border_radius or dpi(0)
-    local widget_bg = beautiful.task_preview_widget_bg or "#000000"
-    local widget_border_color = beautiful.task_preview_widget_border_color
-        or "#ffffff"
-    local widget_border_width = beautiful.task_preview_widget_border_width
-        or dpi(3)
+		placement_fn = nil,
+		widget_margin = dpi(0),
+		widget_border_radius = dpi(0),
+		widget_bg = "#000000",
+		widget_border_color = "#ffffff",
+		widget_border_width = dpi(3)
+	}, opts)
 
     local task_preview_box = awful.popup({
         type = "dropdown_menu",
         visible = false,
         ontop = true,
-        placement = placement_fn,
+        placement = opts.placement_fn,
         widget = wibox.container.background, -- A dummy widget to make awful.popup not scream
         input_passthrough = true,
         bg = "#00000000",
@@ -144,20 +136,13 @@ local enable = function(opts)
             -- Update task preview contents
             task_preview_box.widget = draw_widget(
                 c,
-                opts.structure,
-                screen_radius,
-                widget_bg,
-                widget_border_color,
-                widget_border_width,
-                margin,
-                widget_width,
-                widget_height
+                opts
             )
         end
 
         if not placement_fn then
-            task_preview_box.x = s.geometry.x + widget_x
-            task_preview_box.y = s.geometry.y + widget_y
+            task_preview_box.x = s.geometry.x + opts.x
+            task_preview_box.y = s.geometry.y + opts.y
         end
 
         task_preview_box.visible = v

--- a/widget/task_preview.lua
+++ b/widget/task_preview.lua
@@ -99,7 +99,8 @@ local function draw_widget(
     end
 
     for _, w in ipairs(widget:get_children_by_id("icon_role")) do
-        w.image = c.icon -- TODO: detect clienticon
+	  w.image = c.icon -- TODO: detect clienticon
+	  w.client = c
     end
 
     return widget
@@ -108,7 +109,7 @@ end
 local enable = function(opts)
     local opts = helpers.util.retrieveArguments({
 		"task_preview",
-		{ "x" , "y", "height", "width", "placement_fn" },
+		{ "x" , "y", "height", "width", "placement_fn", "widget_template" },
 		x = dpi(20),
 		y = dpi(20),
 		height = dpi(200),
@@ -116,6 +117,7 @@ local enable = function(opts)
 		margin = dpi(1),
 		
 		placement_fn = nil,
+		widget_template = nil,
 		widget_margin = dpi(0),
 		widget_border_radius = dpi(0),
 		widget_bg = "#000000",

--- a/widget/window_switcher.lua
+++ b/widget/window_switcher.lua
@@ -10,443 +10,291 @@ local window_switcher_first_client -- The client that was focused when the windo
 local window_switcher_minimized_clients = {} -- The clients that were minimized when the window switcher was activated
 local window_switcher_grabber
 
+local task_preview = require(tostring(...):match(".*bling") .. ".widget.task_preview")
+
 local get_num_clients = function()
-    local minimized_clients_in_tag = 0
-    local matcher = function(c)
-        return awful.rules.match(
-            c,
-            {
-                minimized = true,
-                skip_taskbar = false,
-                hidden = false,
-                first_tag = awful.screen.focused().selected_tag,
-            }
-        )
-    end
-    for c in awful.client.iterate(matcher) do
-        minimized_clients_in_tag = minimized_clients_in_tag + 1
-    end
-    return minimized_clients_in_tag + #awful.screen.focused().clients
+  local minimized_clients_in_tag = 0
+  local matcher = function(c)
+	return awful.rules.match(
+	  c,
+	  {
+		minimized = true,
+		skip_taskbar = false,
+		hidden = false,
+		first_tag = awful.screen.focused().selected_tag,
+	  }
+	)
+  end
+  for c in awful.client.iterate(matcher) do
+	minimized_clients_in_tag = minimized_clients_in_tag + 1
+  end
+  return minimized_clients_in_tag + #awful.screen.focused().clients
 end
 
 local window_switcher_hide = function(window_switcher_box)
-    -- Add currently focused client to history
-    if client.focus then
-        local window_switcher_last_client = client.focus
-        awful.client.focus.history.add(window_switcher_last_client)
-        -- Raise client that was focused originally
-        -- Then raise last focused client
-        if
-            window_switcher_first_client and window_switcher_first_client.valid
-        then
-            window_switcher_first_client:raise()
-            window_switcher_last_client:raise()
-        end
-    end
+  -- Add currently focused client to history
+  if client.focus then
+	local window_switcher_last_client = client.focus
+	awful.client.focus.history.add(window_switcher_last_client)
+	-- Raise client that was focused originally
+	-- Then raise last focused client
+	if
+	  window_switcher_first_client and window_switcher_first_client.valid
+	then
+	  window_switcher_first_client:raise()
+	  window_switcher_last_client:raise()
+	end
+  end
 
-    -- Minimize originally minimized clients
-    local s = awful.screen.focused()
-    for _, c in pairs(window_switcher_minimized_clients) do
-        if c and c.valid and not (client.focus and client.focus == c) then
-            c.minimized = true
-        end
-    end
-    -- Reset helper table
-    window_switcher_minimized_clients = {}
+  -- Minimize originally minimized clients
+  local s = awful.screen.focused()
+  for _, c in pairs(window_switcher_minimized_clients) do
+	if c and c.valid and not (client.focus and client.focus == c) then
+	  c.minimized = true
+	end
+  end
+  -- Reset helper table
+  window_switcher_minimized_clients = {}
 
-    -- Resume recording focus history
-    awful.client.focus.history.enable_tracking()
-    -- Stop and hide window_switcher
-    awful.keygrabber.stop(window_switcher_grabber)
-    window_switcher_box.visible = false
+  -- Resume recording focus history
+  awful.client.focus.history.enable_tracking()
+  -- Stop and hide window_switcher
+  awful.keygrabber.stop(window_switcher_grabber)
+  window_switcher_box.visible = false
 end
 
-local function draw_widget(
-    type,
-    background,
-    border_width,
-    border_radius,
-    border_color,
-    clients_spacing,
-    client_icon_horizontal_spacing,
-    client_width,
-    client_height,
-    client_margins,
-    thumbnail_margins,
-    thumbnail_scale,
-    name_margins,
-    name_valign,
-    name_forced_width,
-    name_font,
-    name_normal_color,
-    name_focus_color,
-    icon_valign,
-    icon_width,
-    mouse_keys
-)
-    local tasklist_widget = type == "thumbnail"
-            and awful.widget.tasklist({
-                screen = awful.screen.focused(),
-                filter = awful.widget.tasklist.filter.currenttags,
-                buttons = mouse_keys,
-                style = {
-                    font = name_font,
-                    fg_normal = name_normal_color,
-                    fg_focus = name_focus_color,
-                },
-                layout = {
-                    layout = wibox.layout.flex.horizontal,
-                    spacing = clients_spacing,
-                },
-                widget_template = {
-                    widget = wibox.container.background,
-                    id = "bg_role",
-                    forced_width = client_width,
-                    forced_height = client_height,
-                    create_callback = function(self, c, _, __)
-                        local content = gears.surface(c.content)
-                        local cr = cairo.Context(content)
-                        local x, y, w, h = cr:clip_extents()
-                        local img = cairo.ImageSurface.create(
-                            cairo.Format.ARGB32,
-                            w - x,
-                            h - y
-                        )
-                        cr = cairo.Context(img)
-                        cr:set_source_surface(content, 0, 0)
-                        cr.operator = cairo.Operator.SOURCE
-                        cr:paint()
-                        self:get_children_by_id("thumbnail")[1].image =
-                            gears.surface.load(
-                                img
-                            )
-                    end,
-                    {
-                        {
-                            {
-                                horizontal_fit_policy = thumbnail_scale == true
-                                        and "fit"
-                                    or "auto",
-                                vertical_fit_policy = thumbnail_scale == true
-                                        and "fit"
-                                    or "auto",
-                                id = "thumbnail",
-                                widget = wibox.widget.imagebox,
-                            },
-                            margins = thumbnail_margins,
-                            widget = wibox.container.margin,
-                        },
-                        {
-                            {
-                                {
-                                    id = "icon_role",
-                                    widget = wibox.widget.imagebox,
-                                },
-                                forced_width = icon_width,
-                                valign = icon_valign,
-                                widget = wibox.container.place,
-                            },
-                            {
-                                {
-                                    forced_width = name_forced_width,
-                                    valign = name_valign,
-                                    id = "text_role",
-                                    widget = wibox.widget.textbox,
-                                },
-                                margins = name_margins,
-                                widget = wibox.container.margin,
-                            },
-                            spacing = client_icon_horizontal_spacing,
-                            layout = wibox.layout.fixed.horizontal,
-                        },
-                        layout = wibox.layout.flex.vertical,
-                    },
-                },
-            })
-        or awful.widget.tasklist({
-            screen = awful.screen.focused(),
-            filter = awful.widget.tasklist.filter.currenttags,
-            buttons = mouse_keys,
-            style = {
-                font = name_font,
-                fg_normal = name_normal_color,
-                fg_focus = name_focus_color,
-            },
-            layout = {
-                layout = wibox.layout.fixed.vertical,
-                spacing = clients_spacing,
-            },
-            widget_template = {
-                widget = wibox.container.background,
-                id = "bg_role",
-                forced_width = client_width,
-                forced_height = client_height,
-                {
-                    {
-                        {
-                            id = "icon_role",
-                            widget = wibox.widget.imagebox,
-                        },
-                        forced_width = icon_width,
-                        valign = icon_valign,
-                        widget = wibox.container.place,
-                    },
-                    {
-                        {
-                            forced_width = name_forced_width,
-                            valign = name_valign,
-                            id = "text_role",
-                            widget = wibox.widget.textbox,
-                        },
-                        margins = name_margins,
-                        widget = wibox.container.margin,
-                    },
-                    spacing = client_icon_horizontal_spacing,
-                    layout = wibox.layout.fixed.horizontal,
-                },
-            },
-        })
+local function draw_widget(opts)
 
-    return wibox.widget({
-        {
-            tasklist_widget,
-            margins = client_margins,
-            widget = wibox.container.margin,
-        },
-        shape_border_width = border_width,
-        shape_border_color = border_color,
-        bg = background,
-        shape = helpers.shape.rrect(border_radius),
-        widget = wibox.container.background,
-    })
+  return awful.widget.tasklist {
+	screen = awful.screen.focused(),
+	filter = awful.widget.tasklist.filter.currenttags,
+	buttons = opts.mouse_buttons,
+	style = opts.tasklist_style,
+	layout = opts.tasklist_layout,
+	widget_template = {
+	  widget = wibox.container.background,
+	  create_callback = function(self, c)
+		self.widget = task_preview.draw_widget(c, opts.task_preview_opts)
+	  end
+	}
+  } 
 end
 
 local enable = function(opts)
-    local opts = opts or {}
+  opts = opts or {}
 
-    local type = opts.type or "thumbnail"
-    local background = beautiful.window_switcher_widget_bg or "#000000"
-    local border_width = beautiful.window_switcher_widget_border_width or dpi(3)
-    local border_radius = beautiful.window_switcher_widget_border_radius
-        or dpi(0)
-    local border_color = beautiful.window_switcher_widget_border_color
-        or "#ffffff"
-    local clients_spacing = beautiful.window_switcher_clients_spacing or dpi(20)
-    local client_icon_horizontal_spacing = beautiful.window_switcher_client_icon_horizontal_spacing
-        or dpi(5)
-    local client_width = beautiful.window_switcher_client_width
-        or dpi(type == "thumbnail" and 150 or 500)
-    local client_height = beautiful.window_switcher_client_height
-        or dpi(type == "thumbnail" and 250 or 50)
-    local client_margins = beautiful.window_switcher_client_margins or dpi(10)
-    local thumbnail_margins = beautiful.window_switcher_thumbnail_margins
-        or dpi(5)
-    local thumbnail_scale = beautiful.thumbnail_scale or false
-    local name_margins = beautiful.window_switcher_name_margins or dpi(10)
-    local name_valign = beautiful.window_switcher_name_valign or "center"
-    local name_forced_width = beautiful.window_switcher_name_forced_width
-        or dpi(type == "thumbnail" and 200 or 550)
-    local name_font = beautiful.window_switcher_name_font or beautiful.font
-    local name_normal_color = beautiful.window_switcher_name_normal_color
-        or "#FFFFFF"
-    local name_focus_color = beautiful.window_switcher_name_focus_color
-        or "#FF0000"
-    local icon_valign = beautiful.window_switcher_icon_valign or "center"
-    local icon_width = beautiful.window_switcher_icon_width or dpi(40)
 
-    local hide_window_switcher_key = opts.hide_window_switcher_key or "Escape"
+  local opts = helpers.util.retrieveArguments({
+	"window_switcher",
+	".*_key",
+	background = "#000000",
+	border_width = 1,
+	border_color = "#ffffff",
 
-    local select_client_key = opts.select_client_key or 1
-    local minimize_key = opts.minimize_key or "n"
-    local unminimize_key = opts.unminimize_key or "N"
-    local kill_client_key = opts.kill_client_key or "q"
+	-- NES: Cut out most of the arguments here since not necessary, user can modify them in widget_template
+	box_margins = 10,
+	box_maximum_height = dpi(300),
+	tasklist_style = {
+	  fg_focus = "#ff0000"
+	},
+	tasklist_layout = nil,
+	task_preview_opts = {
+	  widget_template = {
+		{
+		  -- NES: Constraint is required to give the bottom bits space to breathe.
+		  {
+		  widget = wibox.widget.imagebox,
+		  id = 'image_role'
+		},
+		  widget = wibox.container.constraint,
+		  height = 270
+		},
+		{
+		  layout = wibox.layout.fixed.horizontal,
+		  {
+			widget = wibox.widget.imagebox,
+			id = 'icon_role'
+		  },
+		  {
+			widget = wibox.widget.textbox,
+			id = 'name_role'
+		  }
+		},
+		layout = wibox.layout.fixed.vertical
+	  }
+	}, 
 
-    local cycle_key = opts.cycle_key or "Tab"
+	hide_window_switcher_key = "Escape",
 
-    local previous_key = opts.previous_key or "Left"
-    local next_key = opts.next_key or "Right"
+	-- NES: Felt like it was missing so added it
+	placement = awful.placement.centered,
+	box_shape = gears.shape.rectangle,
+	exit_on_modifier_release = false,
+	
+	minimize_key = 'n',
+	unminimize_key = "N",
+	kill_client_key = "q",
+	cycle_key = "Tab",
+	previous_key = "Left",
+	next_key = "Right",
 
-    local vim_previous_key = opts.vim_previous_key or "h"
-    local vim_next_key = opts.vim_next_key or "l"
+	vim_previous_key = "h",
+	vim_next_key = "l",
 
-    local scroll_previous_key = opts.scroll_previous_key or 4
-    local scroll_next_key = opts.scroll_next_key or 5
+	-- NES: Renamed these
+	select_client_btn = 1,
+	scroll_previous_btn = 4,
+	scroll_next_btn = 5
+  }, opts)
 
-    local window_switcher_box = awful.popup({
-        bg = "#00000000",
-        visible = false,
-        ontop = true,
-        placement = awful.placement.centered,
-        screen = awful.screen.focused(),
-        widget = wibox.container.background, -- A dummy widget to make awful.popup not scream
-        widget = {
-            {
-                draw_widget(),
-                margins = client_margins,
-                widget = wibox.container.margin,
-            },
-            shape_border_width = border_width,
-            shape_border_color = border_color,
-            bg = background,
-            shape = helpers.shape.rrect(border_radius),
-            widget = wibox.container.background,
-        },
-    })
+  local window_switcher_box = awful.popup({
+	bg = opts.background,
+	maximum_height = opts.box_maximum_height,
+	visible = false,
+	ontop = true,
+	placement = opts.placement,
+	screen = awful.screen.focused(),
+	-- NES: You redefine it anyway, what exactly is the point?
+	-- widget = wibox.container.background, -- A dummy widget to make awful.popup not scream
+	widget = {
+	  draw_widget(opts),
+	  margins = opts.box_margins,
+	  widget = wibox.container.margin,
+	},
+	border_width = opts.border_width,
+	border_color = opts.border_color,
+	bg = background,
+	shape = opts.box_shape
+  })
 
-    local mouse_keys = gears.table.join(
-        awful.button({
-            modifiers = { "Any" },
-            button = select_client_key,
-            on_press = function(c)
-                client.focus = c
-            end,
-        }),
+  -- NES: Removed the 'Any' since it served no purpose
+  -- NES: Also renamed this
+  opts.mouse_buttons = gears.table.join(
+	awful.button({ },
+	  opts.select_client_btn,
+	  function(c)
+		client.focus = c
+	end),
 
-        awful.button({
-            modifiers = { "Any" },
-            button = scroll_previous_key,
-            on_press = function()
-                awful.client.focus.byidx(-1)
-            end,
-        }),
+	awful.button({}, opts.scroll_previous_btn, function()
+	  awful.client.focus.byidx(-1)
+	end
+	),
 
-        awful.button({
-            modifiers = { "Any" },
-            button = scroll_next_key,
-            on_press = function()
-                awful.client.focus.byidx(1)
-            end,
-        })
-    )
+	awful.button({},opts.scroll_next_btn,function()
+	  awful.client.focus.byidx(1)
+	end)
+  )
 
-    local keyboard_keys = {
-        [hide_window_switcher_key] = function()
-            window_switcher_hide(window_switcher_box)
-        end,
+  opts.keyboard_keys = {
+	[opts.hide_window_switcher_key] = function()
+	  window_switcher_hide(window_switcher_box)
+	end,
 
-        [minimize_key] = function()
-            if client.focus then
-                client.focus.minimized = true
-            end
-        end,
-        [unminimize_key] = function()
-            if awful.client.restore() then
-                client.focus = awful.client.restore()
-            end
-        end,
-        [kill_client_key] = function()
-            if client.focus then
-                client.focus:kill()
-            end
-        end,
+	[opts.minimize_key] = function()
+	  if client.focus then
+		client.focus.minimized = true
+	  end
+	end,
+	[opts.unminimize_key] = function()
+	  if awful.client.restore() then
+		client.focus = awful.client.restore()
+	  end
+	end,
+	[opts.kill_client_key] = function()
+	  if client.focus then
+		client.focus:kill()
+	  end
+	end,
 
-        [cycle_key] = function()
-            awful.client.focus.byidx(1)
-        end,
+	[opts.cycle_key] = function()
+	  awful.client.focus.byidx(1)
+	end,
 
-        [previous_key] = function()
-            awful.client.focus.byidx(1)
-        end,
-        [next_key] = function()
-            awful.client.focus.byidx(-1)
-        end,
+	[opts.previous_key] = function()
+	  awful.client.focus.byidx(1)
+	end,
+	[opts.next_key] = function()
+	  awful.client.focus.byidx(-1)
+	end,
 
-        [vim_previous_key] = function()
-            awful.client.focus.byidx(1)
-        end,
-        [vim_next_key] = function()
-            awful.client.focus.byidx(-1)
-        end,
-    }
+	[opts.vim_previous_key] = function()
+	  awful.client.focus.byidx(1)
+	end,
+	[opts.vim_next_key] = function()
+	  awful.client.focus.byidx(-1)
+	end,
+  }
 
-    window_switcher_box:connect_signal("property::width", function()
-        if window_switcher_box.visible and get_num_clients() == 0 then
-            window_switcher_hide(window_switcher_box)
-        end
-    end)
+  window_switcher_box:connect_signal("property::width", function()
+	if window_switcher_box.visible and get_num_clients() == 0 then
+	  window_switcher_hide(window_switcher_box)
+	end
+  end)
 
-    window_switcher_box:connect_signal("property::height", function()
-        if window_switcher_box.visible and get_num_clients() == 0 then
-            window_switcher_hide(window_switcher_box)
-        end
-    end)
+  window_switcher_box:connect_signal("property::height", function()
+	if window_switcher_box.visible and get_num_clients() == 0 then
+	  window_switcher_hide(window_switcher_box)
+	end
+  end)
 
-    awesome.connect_signal("bling::window_switcher::turn_on", function()
-        local number_of_clients = get_num_clients()
-        if number_of_clients == 0 then
-            return
-        end
+  awesome.connect_signal("bling::window_switcher::show", function()
+	local number_of_clients = get_num_clients()
+	if number_of_clients == 0 then
+	  return
+	end
 
-        -- Store client that is focused in a variable
-        window_switcher_first_client = client.focus
+	-- Store client that is focused in a variable
+	window_switcher_first_client = client.focus
 
-        -- Stop recording focus history
-        awful.client.focus.history.disable_tracking()
+	-- Stop recording focus history
+	awful.client.focus.history.disable_tracking()
 
-        -- Go to previously focused client (in the tag)
-        awful.client.focus.history.previous()
+	-- Go to previously focused client (in the tag)
+	awful.client.focus.history.previous()
 
-        -- Track minimized clients
-        -- Unminimize them
-        -- Lower them so that they are always below other
-        -- originally unminimized windows
-        local clients = awful.screen.focused().selected_tag:clients()
-        for _, c in pairs(clients) do
-            if c.minimized then
-                table.insert(window_switcher_minimized_clients, c)
-                c.minimized = false
-                c:lower()
-            end
-        end
+	-- Track minimized clients
+	-- Unminimize them
+	-- Lower them so that they are always below other
+	-- originally unminimized windows
+	local clients = awful.screen.focused().selected_tag:clients()
+	for _, c in pairs(clients) do
+	  if c.minimized then
+		table.insert(window_switcher_minimized_clients, c)
+		c.minimized = false
+		c:lower()
+	  end
+	end
 
-        -- Start the keygrabber
-        window_switcher_grabber = awful.keygrabber.run(function(_, key, event)
-            if event == "release" then
-                -- Hide if the modifier was released
-                -- We try to match Super or Alt or Control since we do not know which keybind is
-                -- used to activate the window switcher (the keybind is set by the user in keys.lua)
-                if
-                    key:match("Super")
-                    or key:match("Alt")
-                    or key:match("Control")
-                then
-                    window_switcher_hide(window_switcher_box)
-                end
-                -- Do nothing
-                return
-            end
+	-- Start the keygrabber
+	window_switcher_grabber = awful.keygrabber.run(function(_, key, event)
+	  if event == "release" and opts.exit_on_modifier_release then
+		-- Hide if the modifier was released
+		-- We try to match Super or Alt or Control since we do not know which keybind is
+		-- -- used to activate the window switcher (the keybind is set by the user in keys.lua)
+		if
+		  key:match("Super")
+		  or key:match("Alt")
+		  or key:match("Control")
+		then
+		  window_switcher_hide(window_switcher_box)
+		end
+		-- Do nothing
+	  end
 
-            -- Run function attached to key, if it exists
-            if keyboard_keys[key] then
-                keyboard_keys[key]()
-            end
-        end)
+	  -- Run function attached to key, if it exists
+	  if opts.keyboard_keys[key] then
+		opts.keyboard_keys[key]()
+	  end
 
-        window_switcher_box.widget = draw_widget(
-            type,
-            background,
-            border_width,
-            border_radius,
-            border_color,
-            clients_spacing,
-            client_icon_horizontal_spacing,
-            client_width,
-            client_height,
-            client_margins,
-            thumbnail_margins,
-            thumbnail_scale,
-            name_margins,
-            name_valign,
-            name_forced_width,
-            name_font,
-            name_normal_color,
-            name_focus_color,
-            icon_valign,
-            icon_width,
-            mouse_keys
-        )
-        window_switcher_box.visible = true
-    end)
+	  -- return true -- NES: Continue mouse grabbing
+	end)
+
+	-- NES: Removed the abomination that was here
+	window_switcher_box.widget = draw_widget(opts)
+	window_switcher_box.visible = true
+  end)
 end
 
+-- NES: Can't we just return the function directly
 return { enable = enable }


### PR DESCRIPTION
mainly because the current thing upsets me :( 
Maybe useless but I dont think it could hurt much 

@Nooo37 what do you think?
sorry for the mess q-q

And I still havent done any of kasper's widgets 

Basic usage
```lua
function (args)
local helpers = require(tostring(...):match(".*bling") .. ".helpers")
local options = helpers.util.retrieveArguments({
"<Module Name>"
{ "other" },
color = "#fff",
other = "aaa"
}, args)
end
```

So itll automatically pick up arguments from args,
and from `beautiful.modulename_key`
or from `beautiful.modulename.key`
any keys in the ignore list (the first nested table) wont be picked up from beautiful but only from the command line arguments