### PR TITLE
Unify the layout icon path search and search in all `package.path` paths

### DIFF
--- a/layout/centered.lua
+++ b/layout/centered.lua
@@ -1,7 +1,4 @@
 local awful = require("awful")
-local gears = require("gears")
-local gcolor = require("gears.color")
-local beautiful = require("beautiful")
 local math = math
 
 local mylayout = {}
@@ -58,6 +55,7 @@ function mylayout.arrange(p)
     -- iterate through slaves
     for idx = 1, nslaves do -- idx=nmaster+1,#p.clients do
         local c = p.clients[idx + nmaster]
+        local g
         if idx % 2 == 0 then
             g = {
                 x = area.x,
@@ -83,20 +81,4 @@ function mylayout.arrange(p)
     end
 end
 
-local icon_raw = gears.filesystem.get_configuration_dir()
-    .. tostring(...):match("^.*bling"):gsub("%.", "/")
-    .. "/icons/layouts/centered.png"
-
-local function get_icon()
-    if icon_raw ~= nil then
-        return gcolor.recolor_image(icon_raw, beautiful.fg_normal)
-    else
-        return nil
-    end
-end
-
-return {
-    layout = mylayout,
-    icon_raw = icon_raw,
-    get_icon = get_icon,
-}
+return mylayout

--- a/layout/deck.lua
+++ b/layout/deck.lua
@@ -1,8 +1,3 @@
-local awful = require("awful")
-local gears = require("gears")
-local gcolor = require("gears.color")
-local beautiful = require("beautiful")
-
 local mylayout = {}
 
 mylayout.name = "deck"
@@ -39,20 +34,4 @@ function mylayout.arrange(p)
     end
 end
 
-local icon_raw = gears.filesystem.get_configuration_dir()
-    .. tostring(...):match("^.*bling"):gsub("%.", "/")
-    .. "/icons/layouts/deck.png"
-
-local function get_icon()
-    if icon_raw ~= nil then
-        return gcolor.recolor_image(icon_raw, beautiful.fg_normal)
-    else
-        return nil
-    end
-end
-
-return {
-    layout = mylayout,
-    icon_raw = icon_raw,
-    get_icon = get_icon,
-}
+return mylayout

--- a/layout/equalarea.lua
+++ b/layout/equalarea.lua
@@ -1,6 +1,3 @@
-local gears = require("gears")
-local gcolor = require("gears.color")
-local beautiful = require("beautiful")
 local math = math
 local screen = screen
 local mylayout = {}
@@ -77,20 +74,4 @@ function mylayout.arrange(p)
     divide(p, g, 1, #cls, cls, mwfact, mcount)
 end
 
-local icon_raw = gears.filesystem.get_configuration_dir()
-    .. tostring(...):match("^.*bling"):gsub("%.", "/")
-    .. "/icons/layouts/equalarea.png"
-
-local function get_icon()
-    if icon_raw ~= nil then
-        return gcolor.recolor_image(icon_raw, beautiful.fg_normal)
-    else
-        return nil
-    end
-end
-
-return {
-    layout = mylayout,
-    icon_raw = icon_raw,
-    get_icon = get_icon,
-}
+return mylayout

--- a/layout/horizontal.lua
+++ b/layout/horizontal.lua
@@ -1,7 +1,3 @@
-local awful = require("awful")
-local gears = require("gears")
-local gcolor = require("gears.color")
-local beautiful = require("beautiful")
 local math = math
 
 local mylayout = {}
@@ -57,20 +53,4 @@ function mylayout.arrange(p)
     end
 end
 
-local icon_raw = gears.filesystem.get_configuration_dir()
-    .. tostring(...):match("^.*bling"):gsub("%.", "/")
-    .. "/icons/layouts/horizontal.png"
-
-local function get_icon()
-    if icon_raw ~= nil then
-        return gcolor.recolor_image(icon_raw, beautiful.fg_normal)
-    else
-        return nil
-    end
-end
-
-return {
-    layout = mylayout,
-    icon_raw = icon_raw,
-    get_icon = get_icon,
-}
+return mylayout

--- a/layout/init.lua
+++ b/layout/init.lua
@@ -1,30 +1,44 @@
 local beautiful = require("beautiful")
+local gears = require("gears")
 
-local mstab = require(... .. ".mstab")
-beautiful.layout_mstab = mstab.get_icon()
+local M = {}
+local relative_lua_path = tostring(...)
 
-local vertical = require(... .. ".vertical")
-beautiful.layout_vertical = vertical.get_icon()
+local function get_layout_icon_path(name)
+    local relative_icon_path = relative_lua_path
+        :match("^.*bling"):gsub("%.", "/")
+        .. "/icons/layouts/" .. name .. ".png"
 
-local horizontal = require(... .. ".horizontal")
-beautiful.layout_horizontal = horizontal.get_icon()
+    for p in package.path:gmatch('([^;]+)') do
+        p = p:gsub("?.*", "")
+        local absolute_icon_path = p .. relative_icon_path
+        if gears.filesystem.file_readable(absolute_icon_path) then
+            return absolute_icon_path
+        end
+    end
+end
 
-local centered = require(... .. ".centered")
-beautiful.layout_centered = centered.get_icon()
+local function get_icon(icon_raw)
+    if icon_raw ~= nil then
+        return gears.color.recolor_image(icon_raw, beautiful.fg_normal)
+    else
+        return nil
+    end
+end
 
-local equalarea = require(... .. ".equalarea")
-beautiful.layout_equalarea = equalarea.get_icon()
-
-local deck = require(... .. ".deck")
-beautiful.layout_deck = deck.get_icon()
-
-local layout = {
-    mstab = mstab.layout,
-    centered = centered.layout,
-    vertical = vertical.layout,
-    horizontal = horizontal.layout,
-    equalarea = equalarea.layout,
-    deck = deck.layout,
+local layouts = {
+    "mstab",
+    "vertical",
+    "horizontal",
+    "centered",
+    "equalarea",
+    "deck"
 }
 
-return layout
+for _, layout_name in ipairs(layouts) do
+    local icon_raw = get_layout_icon_path(layout_name)
+    beautiful["layout_" .. layout_name] = get_icon(icon_raw)
+    M[layout_name] = require(... .. "." .. layout_name)
+end
+
+return M

--- a/layout/mstab.lua
+++ b/layout/mstab.lua
@@ -1,7 +1,6 @@
 local awful = require("awful")
 local gears = require("gears")
 local wibox = require("wibox")
-local gcolor = require("gears.color")
 local beautiful = require("beautiful")
 
 local mylayout = {}
@@ -242,16 +241,4 @@ function mylayout.arrange(p)
     )
 end
 
-local icon_raw = gears.filesystem.get_configuration_dir()
-    .. tostring(...):match("^.*bling"):gsub("%.", "/")
-    .. "/icons/layouts/mstab.png"
-
-local function get_icon()
-    if icon_raw ~= nil then
-        return gcolor.recolor_image(icon_raw, beautiful.fg_normal)
-    else
-        return nil
-    end
-end
-
-return { layout = mylayout, icon_raw = icon_raw, get_icon = get_icon }
+return mylayout

--- a/layout/vertical.lua
+++ b/layout/vertical.lua
@@ -1,7 +1,3 @@
-local awful = require("awful")
-local gears = require("gears")
-local gcolor = require("gears.color")
-local beautiful = require("beautiful")
 local math = math
 
 local mylayout = {}
@@ -57,20 +53,4 @@ function mylayout.arrange(p)
     end
 end
 
-local icon_raw = gears.filesystem.get_configuration_dir()
-    .. tostring(...):match("^.*bling"):gsub("%.", "/")
-    .. "/icons/layouts/vertical.png"
-
-local function get_icon()
-    if icon_raw ~= nil then
-        return gcolor.recolor_image(icon_raw, beautiful.fg_normal)
-    else
-        return nil
-    end
-end
-
-return {
-    layout = mylayout,
-    icon_raw = icon_raw,
-    get_icon = get_icon,
-}
+return mylayout


### PR DESCRIPTION
This PR moves the responsibility for getting the layout icons from the layouts itself to the `layout/init.lua` file as the code was just repeating itself anyway. Instead of searching in the config directory only, it now searches in all paths that are mentioned in `package.path` (because when bling is loaded successfully, the icons will obviously be in one of those paths too). This should fix #136. 

It also makes it possible to require layouts directly (ie `awful.layout.layouts { require("bling.layout.centered") }`)