### PR TITLE
Improved swallowing

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@ The following developers have contributed major code to bling:
  * [HumblePresent](https://github.com/HumblePresent)
  * [Kasper24](https://github.com/Kasper24)
  * [undefinedDarkness](https://github.com/undefinedDarkness)
+ * [eylles](https://github.com/eylles)

--- a/docs/module/swal.md
+++ b/docs/module/swal.md
@@ -13,8 +13,9 @@ bling.module.window_swallowing.toggle() -- toggles window swallowing
 
 ### Theme Variables
 ```lua
-theme.dont_swallow_classname_list   = {"firefox", "Gimp"} -- list of class names that should not be swallowed
-theme.dont_swallow_filter_activated = true                -- whether the filter above should be active
+theme.parent_filter_list   = {"firefox", "Gimp"} -- class names list of parents that should not be swallowed
+theme.child_filter_list    = { "Dragon" } -- class names list that should not swallow their parents
+theme.swallowing_filter = true                -- whether the filters above should be active
 ```
 
 ### Preview

--- a/docs/module/swal.md
+++ b/docs/module/swal.md
@@ -14,8 +14,8 @@ bling.module.window_swallowing.toggle() -- toggles window swallowing
 ### Theme Variables
 ```lua
 theme.parent_filter_list   = {"firefox", "Gimp"} -- class names list of parents that should not be swallowed
-theme.child_filter_list    = { "Dragon" } -- class names list that should not swallow their parents
-theme.swallowing_filter = true                -- whether the filters above should be active
+theme.child_filter_list    = { "Dragon" }        -- class names list that should not swallow their parents
+theme.swallowing_filter = true                   -- whether the filters above should be active
 ```
 
 ### Preview

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -56,6 +56,8 @@ local function manage_clientspawn(c)
     local parent_client = awful.client.focus.history.get(c.screen, 1)
     if not parent_client then
         return
+    elseif parent_client.type == "dialog" or parent_client.type == "splash" then
+        return
     end
 
     -- io.popen is normally discouraged. Should probably be changed

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -88,8 +88,10 @@ local function manage_clientspawn(c)
         and check_swallow(parent_client.class, c.class)
     then
         c:connect_signal("unmanage", function()
-            helpers.client.turn_on(parent_client)
-            helpers.client.sync(parent_client, c)
+            if parent_client then
+                helpers.client.turn_on(parent_client)
+                helpers.client.sync(parent_client, c)
+            end
         end)
 
         helpers.client.sync(c, parent_client)

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -12,11 +12,12 @@ local window_swallowing_activated = false
 
 -- you might want to add or remove applications here
 local parent_filter_list = beautiful.parent_filter_list
+    or beautiful.dont_swallow_classname_list
     or { "firefox", "Gimp", "Google-chrome" }
 local child_filter_list = beautiful.child_filter_list
-    or { }
+    or beautiful.dont_swallow_classname_list or { }
 local swallowing_filter = beautiful.swallowing_filter
-    or true
+    or beautiful.dont_swallow_filter_activated or true
 
 -- check if element exist in table
 local function is_in_table(element, table)

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -79,7 +79,6 @@ local function manage_clientspawn(c)
 
     get_parent_pid(c.pid, function(err, ppid)
         if err then
-            error(err)
             return
         end
         parent_pid = ppid

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -38,16 +38,14 @@ local function manage_clientspawn(c)
     end
 
     -- io.popen is normally discouraged. Should probably be changed
-    local handle = io.popen(
-        [[pstree -T -p -a -s ]]
-            .. tostring(c.pid)
-            .. [[ | sed '2q;d' | grep -o '[0-9]*$' | tr -d '\n']]
-    )
+    -- returns "init(1)---ancestorA(pidA)---ancestorB(pidB)...---process(pid)"
+    local handle = io.popen("pstree -A -p -s " .. tostring(c.pid))
     local parent_pid = handle:read("*a")
     handle:close()
 
     if
-        (tostring(parent_pid) == tostring(parent_client.pid))
+        -- will search for "(parent_client.pid)" inside the parent_pid string
+        ( tostring(parent_pid):find("("..tostring(parent_client.pid)..")") )
         and check_if_swallow(c)
     then
         c:connect_signal("unmanage", function()

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -19,45 +19,31 @@ local activate_dont_swallow_filter = beautiful.dont_swallow_filter_activated
     or true
 
 -- check if element exist in table
-local function is_in_Table(element, table)
-    local res = false
+local function is_in_table(element, table)
     for _, value in pairs(table) do
         if element:match(value) then
-            res = true
-            break
+            return true
         end
+    return false
     end
-    return res
 end
 
 -- checks if client classname can be swallowed
 local function check_if_swallow(class)
-    local res
     if not activate_dont_swallow_filter then
-        res = true
+        return true
     else
-        if is_in_Table(class, dont_swallow_classname_list) then
-            res = false
-        else
-            res = true
-        end
+        return not is_in_table(class, dont_swallow_classname_list)
     end
-    return res
 end
 
 -- checks if client classname can swallow it's parent
 local function check_can_swallow(class)
-    local res
     if not activate_dont_swallow_filter then
-        res = true
+        return true
     else
-        if is_in_Table(class, cant_swallow_classname_list) then
-            res = false
-        else
-            res = true
-        end
+        return not is_in_table(class, cant_swallow_classname_list)
     end
-    return res
 end
 
 -- the function that will be connected to / disconnected from the spawn client signal

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -20,29 +20,22 @@ local swallowing_filter = beautiful.swallowing_filter
 
 -- check if element exist in table
 local function is_in_table(element, table)
+    local res = false
     for _, value in pairs(table) do
         if element:match(value) then
-            return true
+            res = true
+            break
         end
-    return false
     end
+    return res
 end
 
 -- checks if parent's classname can be swallowed
-local function check_parent(class)
+local function check_swallow(class, list)
     if not swallowing_filter then
         return true
     else
-        return not is_in_table(class, parent_filter_list)
-    end
-end
-
--- checks if client's classname can swallow it's parent
-local function check_client(class)
-    if not swallowing_filter then
-        return true
-    else
-        return not is_in_table(class, child_filter_list)
+        return not is_in_table(class, list)
     end
 end
 
@@ -63,7 +56,8 @@ local function manage_clientspawn(c)
     if
         -- will search for "(parent_client.pid)" inside the parent_pid string
         ( tostring(parent_pid):find("("..tostring(parent_client.pid)..")") )
-        and check_parent(parent_client.class) and check_client(c.class)
+        and check_swallow(parent_client.class, parent_filter_list)
+        and check_swallow(c.class, child_filter_list)
     then
         c:connect_signal("unmanage", function()
             helpers.client.turn_on(parent_client)

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -11,11 +11,11 @@ local helpers = require(tostring(...):match(".*bling") .. ".helpers")
 local window_swallowing_activated = false
 
 -- you might want to add or remove applications here
-local dont_swallow_classname_list = beautiful.dont_swallow_classname_list
+local parent_filter_list = beautiful.parent_filter_list
     or { "firefox", "Gimp", "Google-chrome" }
-local cant_swallow_classname_list = beautiful.cant_swallow_classname_list
-    or { "Yad" }
-local activate_dont_swallow_filter = beautiful.dont_swallow_filter_activated
+local child_filter_list = beautiful.child_filter_list
+    or { }
+local swallowing_filter = beautiful.swallowing_filter
     or true
 
 -- check if element exist in table
@@ -28,21 +28,21 @@ local function is_in_table(element, table)
     end
 end
 
--- checks if client classname can be swallowed
-local function check_if_swallow(class)
-    if not activate_dont_swallow_filter then
+-- checks if parent's classname can be swallowed
+local function check_parent(class)
+    if not swallowing_filter then
         return true
     else
-        return not is_in_table(class, dont_swallow_classname_list)
+        return not is_in_table(class, parent_filter_list)
     end
 end
 
--- checks if client classname can swallow it's parent
-local function check_can_swallow(class)
-    if not activate_dont_swallow_filter then
+-- checks if client's classname can swallow it's parent
+local function check_client(class)
+    if not swallowing_filter then
         return true
     else
-        return not is_in_table(class, cant_swallow_classname_list)
+        return not is_in_table(class, child_filter_list)
     end
 end
 
@@ -63,7 +63,7 @@ local function manage_clientspawn(c)
     if
         -- will search for "(parent_client.pid)" inside the parent_pid string
         ( tostring(parent_pid):find("("..tostring(parent_client.pid)..")") )
-        and check_if_swallow(parent_client.class) and check_can_swallow(c.class)
+        and check_parent(parent_client.class) and check_client(c.class)
     then
         c:connect_signal("unmanage", function()
             helpers.client.turn_on(parent_client)


### PR DESCRIPTION
This is an incremental improvement of the swallowing module, so far what has been done:

* Changed the flags for the pstree command so it is a single line with all ancestors.
* Removed usage of sed, grep and tr so the iopopen call should be faster.
* Find and match of parent pid in the ancestors string is done in lua so should be faster.
* Rework the don't swallow filter and add table for clients that cannot swallow their parent.

What i still plan to do:

* ~~Rework the don't swallow filter and add table for clients that cannot swallow their parent.~~ done
* ~~Add persistent properties so parent clients can be restored after awesome restarts~~ can't decide on the better way to implement this so won't do it in this PR

altho i still have those plans the changes could be added to a later PR, also i have a prototype for removing iopopen altogether and instead use an async function but i'm still new to async functions specially in lua so that specific prototype may still have jank in it.

