### PR TITLE
Fix handling of signals in scratchpad when client is nil

### DIFF
--- a/module/scratchpad.lua
+++ b/module/scratchpad.lua
@@ -293,10 +293,10 @@ function Scratchpad:turn_on()
                         animate_turn_on(self, anim_y, "y")
                     end
                     self:emit_signal("inital_apply", c1)
-                    self.client.disconnect_signal("manage", inital_apply)
+                    client.disconnect_signal("manage", inital_apply)
                 end
             end
-            self.client.connect_signal("manage", inital_apply)
+            client.connect_signal("manage", inital_apply)
         end
     end
 end


### PR DESCRIPTION
Fixes #146 for me. I am pretty new to the codebase and could be missing the intention of this area of the code.