### PR TITLE
client helpers use client properties

### DIFF
--- a/helpers/client.lua
+++ b/helpers/client.lua
@@ -7,17 +7,8 @@ local _client = {}
 -- Remove current tag from window's tags
 --
 -- @param c A client
-function _client.turn_off(c, current_tag)
-    if current_tag == nil then
-        current_tag = c.screen.selected_tag
-    end
-    local ctags = {}
-    for k, tag in pairs(c:tags()) do
-        if tag ~= current_tag then
-            table.insert(ctags, tag)
-        end
-    end
-    c:tags(ctags)
+function _client.turn_off(c)
+    c.hidden = true
     c.sticky = false
 end
 
@@ -25,14 +16,7 @@ end
 --
 -- @param c A client
 function _client.turn_on(c)
-    local current_tag = c.screen.selected_tag
-    ctags = { current_tag }
-    for k, tag in pairs(c:tags()) do
-        if tag ~= current_tag then
-            table.insert(ctags, tag)
-        end
-    end
-    c:tags(ctags)
+    c.hidden = false
     c:raise()
     client.focus = c
 end


### PR DESCRIPTION
changed the `_client.turn_off()` and `_client.turn_on()` helpers to use the `c.hidden` property instead of the tagging/untagging dance in accordance to a [comment](https://github.com/BlingCorp/bling/pull/140#issuecomment-1006649215) in #140

so far this seems to work or the swallowing module and i haven't found any particular new corner case

testing for scratchpads and the tabbed module need to be done.