### PR TITLE
Update repository urls in docs

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -10,7 +10,7 @@ This project focuses on that problem - adding new layouts and modules that make 
 
 ## Installation
 - clone this repo into your `~/.config/awesome` folder
-    - `git clone https://github.com/Nooo37/bling.git ~/.config/awesome/bling`
+    - `git clone https://github.com/BlingCorp/bling.git ~/.config/awesome/bling`
 - require the module in your `rc.lua`, and make sure it's under the beautiful module initialization
 
 ```lua
@@ -27,8 +27,8 @@ local bling = require("bling")
 ## Contributors
 A special thanks to all our contributors...
 
-<a href="https://github.com/Nooo37/bling/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Nooo37/bling" />
+<a href="https://github.com/BlingCorp/bling/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=BlingCorp/bling" />
 </a>
 
 Made with [contributors-img](https://contrib.rocks).

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
         <title>Bling Docs</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <meta name="description" content="Utilities for the awesome window manager">
-        <meta name="og:image" content="https://raw.githubusercontent.com/Nooo37/bling/master/images/bling_banner.png">
+        <meta name="og:image" content="https://raw.githubusercontent.com/BlingCorp/bling/master/images/bling_banner.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
         <link rel="stylesheet" href="javacafe.css">
     </head>
@@ -15,7 +15,7 @@
             window.$docsify = {
                 name: 'Bling',
                 nameLink: '/',
-                repo: 'https://github.com/Nooo37/bling',
+                repo: 'https://github.com/BlingCorp/bling',
                 loadSidebar: true,
                 subMaxLevel: 3,
                 homepage: 'home.md'


### PR DESCRIPTION
This pull request simply updates the repository urls in the documentation from `Nooo37/bling` to `BlingCorp/bling` in order to reflect the repository being moved to an organization.