### PR TITLE
Prevent flashing client when only one is present

### DIFF
--- a/module/flash_focus.lua
+++ b/module/flash_focus.lua
@@ -5,7 +5,7 @@ local op = beautiful.flash_focus_start_opacity or 0.6
 local stp = beautiful.flash_focus_step or 0.01
 
 local flashfocus = function(c)
-    if c and #c.first_tag:clients() > 1 then
+    if c and #c.screen.clients > 1 then
         c.opacity = op
         local q = op
         local g = gears.timer({

--- a/module/flash_focus.lua
+++ b/module/flash_focus.lua
@@ -5,7 +5,7 @@ local op = beautiful.flash_focus_start_opacity or 0.6
 local stp = beautiful.flash_focus_step or 0.01
 
 local flashfocus = function(c)
-    if c then
+    if c and #c.first_tag:clients() > 1 then
         c.opacity = op
         local q = op
         local g = gears.timer({


### PR DESCRIPTION
This small change simply prevents a client from flashing when only 1 client is there in a tag. The point of flashfocus is to tell which client is currently focused and flashing a lonely client seems redundant.

Some edge cases for this might include the client being in multiple tags or if the current tag has hidden clients, I'm a beginner with lua so I have not been able to test out these edge cases. Feedback is appreciated.