### PR TITLE
Remove the unnecessary c:raise() call in flash_focus

### DIFF
--- a/module/flash_focus.lua
+++ b/module/flash_focus.lua
@@ -27,11 +27,6 @@ local flashfocus = function(c)
             end
         end)
     end
-
-    -- Bring the focused client to the top
-    if c then
-        c:raise()
-    end
 end
 
 local enable = function()


### PR DESCRIPTION
The flash focus module calls a client's `:raise()`-method. However, since flash focus will only trigger when a window is focused by other means (that is, either manually by clicking a client or with focus-on-hover), there is really no reason for flash_focus to force-raise a client. By default, awesome explicitly sets the `raise` property to `false`, because it is more annoying than anything else (as can be seen in the videos at the bottom).

```lua
-- snippet taken from right at the very bottom of the default rc.lua
client.connect_signal("mouse::enter", function(c)
    c:activate { context = "mouse_enter", raise = false }
end)
```

In addition, since the module is called "flash focus", not "flash raise", the current behavior is likely to be unexpected by a user.

---

Here are two videos showing the difference (they're low quality because of tight file size restrictions from GitHub's side, but that should be enough here):

Before:
https://user-images.githubusercontent.com/53921371/174155529-3789fc68-2f82-4c17-9c05-0e79c1674317.mp4

After:
https://user-images.githubusercontent.com/53921371/174155541-3ec7f624-8da6-4bc8-afe0-9431b207ddec.mp4


