### PR TITLE
Pass `inactive_bool` to bar creation function in `mstab` layout

### DIFF
--- a/layout/mstab.lua
+++ b/layout/mstab.lua
@@ -72,7 +72,11 @@ function update_tabbar(
                 c.minimized = true
             end)
         )
-        local client_box = bar.create(c, (idx == top_idx), buttons)
+        local inactive = false
+        if client.focus == awful.client.getmaster() then
+           inactive = true
+        end
+        local client_box = bar.create(c, (idx == top_idx), buttons, inactive)
         clientlist:add(client_box)
     end
 


### PR DESCRIPTION
This will pass in the `inactive_boll` param when creating the tabs for the `mstab` layout