### PR TITLE
Cache album art for playerctl module

### DIFF
--- a/helpers/filesystem.lua
+++ b/helpers/filesystem.lua
@@ -52,8 +52,15 @@ function _filesystem.list_directory_files(path, exts, recursive)
     return files
 end
 
-function _filesystem.save_image_async_curl(url, filepath, callback)
-    awful.spawn.with_line_callback(string.format("curl -L -s %s -o %s", url, filepath),
+function _filesystem.save_image_async_curl(redownload, create_dirs, url, filepath, callback)
+    if not redownload then
+        if Gio.File.query_exists(Gio.File.new_for_path(filepath)) then
+            callback()
+            return
+        end
+    end
+
+    awful.spawn.with_line_callback(string.format("curl -L -s %s -o %s %s", url, filepath, (create_dirs and "--create-dirs" or "")),
     {
       exit=callback
     })

--- a/signal/playerctl/playerctl_cli.lua
+++ b/signal/playerctl/playerctl_cli.lua
@@ -184,8 +184,8 @@ local function emit_player_metadata(self)
                 callback = function()
                     if title and title ~= "" then
                         if art_url ~= "" then
-                            local art_path = os.tmpname()
-                            helpers.filesystem.save_image_async_curl(art_url, art_path, function()
+                            local art_path = "/tmp/bling_album_art/" .. art_url:gsub("https://", ""):gsub("http://", "")
+                            helpers.filesystem.save_image_async_curl(false, true, art_url, art_path, function()
                                 self:emit_signal("metadata", title, artist, art_path, album, player_name)
                                 capi.awesome.emit_signal("bling::playerctl::title_artist_album", title, artist, art_path)
                             end)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -190,8 +190,8 @@ local function emit_metadata_signal(self, title, artist, artUrl, album, new, pla
     end
 
     if artUrl ~= "" then
-        local art_path = os.tmpname()
-        helpers.filesystem.save_image_async_curl(artUrl, art_path, function()
+        local art_path = "/tmp/bling_album_art/" .. artUrl:gsub("https://", ""):gsub("http://", "")
+        helpers.filesystem.save_image_async_curl(false, true, artUrl, art_path, function()
             self:emit_signal("metadata", title, artist, art_path, album, new, player_name)
             capi.awesome.emit_signal("bling::playerctl::title_artist_album", title, artist, art_path, player_name)
         end)


### PR DESCRIPTION
### Summary
This PR
1. Replaces the usage of `os.tmpname()` with a URL-based path in the playerctl module and prevents album art from being downloaded multiple times, and 
    - The path is determined based on the following logic: all occurences of `https://` and `http://` are first removed from the URL, then `/tmp/bling_album_art .. trimmed_url` is used as the path
2. Adds new params for `save_image_async_curl` function in `helpers/filesystem.lua` (required for 1.):
    - boolean `redownload`: if this is `false` and the file already exists, `curl` isn't called
    - boolean `create_dirs`: if this is `true` the `--create-dirs` flag is added to the `curl` call

This means that
1. Disk space is saved by not unnecessarily re-downloading album art
2. Already downloaded album art will work when you don't have an internet connection
3. For people with slow internet speeds, getting the album art should be faster if it isn't the first time

### Notes
Haven't tested if this works when passing some other values for `redownload` and `create_dirs` to the save image function, but it theoretically should still work just fine