### PR TITLE
add app_launcher docs and basic options descriptions

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,6 +14,7 @@
     - [Playerctl](signals/pctl.md)
 
 - Widgets
+    - [App Launcher](widgets/app_launcher.md)
     - [Tag Preview](widgets/tag_preview.md)
     - [Task Preview](widgets/task_preview.md)
     - [Tabbed Misc](widgets/tabbed_misc.md)

--- a/docs/widgets/app_launcher.md
+++ b/docs/widgets/app_launcher.md
@@ -1,0 +1,126 @@
+## 🎨 App Launcher <!-- {docsify-ignore} -->
+
+A popup application launcher similar to Rofi
+
+![](https://user-images.githubusercontent.com/33443763/140196352-07e444fe-cccd-45ad-93fa-5705f09e516b.png)
+
+*image by [JavaCafe01](https://github.com/JavaCafe01)*
+
+### Usage
+
+To enable:
+
+```lua
+local app_launcher = bling.widget.app_launcher()
+```
+
+To run the app launcher, call `:toggle()` on the launcher.
+
+```lua
+app_launcher:toggle()
+```
+
+### Example Implementation:
+
+```lua
+local args = {
+    apps_per_column = 1,
+    sort_alphabetically = false,
+    reverse_sort_alphabetically = true,
+}
+local app_launcher = bling.widget.app_launcher(args)
+```
+
+### Available Options:
+```lua
+local args = {
+    terminal = "alacritty"                                            -- Set default terminal
+    favorites = { "wezterm" }                                         -- Favorites are given priority and are bubbled to top of the list
+    search_commands = { "" }                                          --  
+    skip_names = { "Discord" }                                        -- List of apps to omit from launcher
+    skip_commands = { "" }                                            -- 
+    skip_empty_icons = true                                           -- Skip applications without icons
+    sort_alphabetically = true                                        -- Sorts applications alphabetically
+    reverse_sort_alphabetically = false                               -- Sort in reverse alphabetical order (NOTE: must set `sort_alphabetically = false` to take effect)
+    select_before_spawn = true                                        -- When selecting by mouse, click once to select app, click once more to open the app.
+    hide_on_left_clicked_outside = true                               -- Hide launcher on left click outside the launcher popup
+    hide_on_right_clicked_outside = true                              -- Hide launcher on right click outside the launcher popup
+    hide_on_launch = true                                             -- Hide launcher when spawning application
+    try_to_keep_index_after_searching = false                         -- After a search, reselect the previously selected app
+    reset_on_hide = true                                              -- When you hide the launcher, reset search query
+    save_history = true                                               -- 
+    wrap_page_scrolling = true                                        -- Allow scrolling to wrap back to beginning/end of launcher list
+    wrap_app_scrolling = true                                         -- 
+
+    default_app_icon_name = ""                                        -- Sets default app icon name for apps without icon names
+    default_app_icon_path = ""                                        -- Sets default app icon path for apps without icon paths
+    icon_theme = ""                                                   -- Set icon theme
+    icons_size = ""                                                   -- Set icon size
+
+    type = "dock"                                                     -- awful.popup type ("dock", "desktop", "normal"...).  See awesomewm docs for more detail
+    show_on_focused_screen = true                                     -- Should app launcher show on currently focused screen
+    screen = awful.screen                                             -- Screen you want the launcher to launch to
+    placement = awful.placement.top_left                              -- Where launcher should be placed ("awful.placement.centered").
+    rubato =                                                          -- 
+    shirnk_width = true                                               -- Automatically shrink width of launcher to fit varying numbers of apps in list (works on apps_per_column)
+    shrink_height = true                                              -- Automatically shrink height of launcher to fit varying numbers of apps in list (works on apps_per_row)
+    background = "#FFFFFF"                                            -- Set bg color
+    shape = function(cr, width, height)
+      gears.shape.rectangle(cr, width, height)
+    end                                                               -- Set shape for launcher
+    prompt_height = dpi(50)                                           -- Prompt height
+    prompt_margins = dpi(30)                                          -- Prompt margins
+    prompt_paddings = dpi(15)                                         -- Prompt padding
+    shape = function(cr, width, height)
+      gears.shape.rectangle(cr, width, height)
+    end                                                               -- Set shape for prompt
+    prompt_color = "#000000"                                          -- Prompt background color
+    prompt_border_width = dpi(0)                                      -- Prompt border width
+    prompt_border_color = "#000000"                                   -- Prompt border color
+    prompt_text_halign = "center"                                     -- Prompt text horizontal alignment
+    prompt_text_valign = "center"                                     -- Prompt text vertical alignment
+    prompt_icon_text_spacing = dpi(10)                                -- Prompt icon text spacing
+    prompt_show_icon = true                                           -- Should prompt show icon (?)
+    prompt_icon_font = "Comic Sans"                                   -- Prompt icon font
+    prompt_icon_color = "#000000"                                     -- Prompt icon color
+    prompt_icon = ""                                                 -- Prompt icon
+    prompt_icon_markup = string.format(
+        "<span size='xx-large' foreground='%s'>%s</span>",
+        args.prompt_icon_color, args.prompt_icon
+    )                                                                 -- Prompt icon markup
+    prompt_text = "<b>Search</b>:"                                    -- Prompt text
+    prompt_start_text = ""                                            -- Set string for prompt to start with
+    prompt_font = "Comic Sans"                                        -- Prompt font
+    prompt_text_color = "#FFFFFF"                                     -- Prompt text color
+    prompt_cursor_color = "#000000"                                   -- Prompt cursor color
+
+    apps_per_row = 3                                                  -- Set how many apps should appear in each row
+    apps_per_column = 3                                               -- Set how many apps should appear in each column
+    apps_margin = {left = dpi(40), right = dpi(40), bottom = dpi(30)} -- Margin between apps
+    apps_spacing = dpi(10)                                            -- Spacing between apps
+    
+    expand_apps = true                                                --
+    app_width = dpi(400)                                              -- Width of each app
+    app_height = dpi(40)                                              -- Height of each app
+    app_shape = function(cr, width, height)
+      gears.shape.rectangle(cr, width, height)
+    end                                                               -- Shape of each app
+    app_normal_color = "#000000"                                      -- App normal color
+    app_normal_hover_color = "#111111"                                -- App normal hover color 
+    app_selected_color = "#FFFFFF"                                    -- App selected color
+    app_selected_hover_color = "#EEEEEE"                              -- App selected hover color
+    app_content_padding = dpi(10)                                     -- App content padding
+    app_content_spacing = dpi(10)                                     -- App content spacing
+    app_show_icon = true                                              -- Should show icon?
+    app_icon_halign = "center"                                        -- App icon horizontal alignment
+    app_icon_width = dpi(70)                                          -- App icon wigth
+    app_icon_height = dpi(70)                                         -- App icon height
+    app_show_name = true                                              -- Should show app name?
+    app_name_generic_name_spacing = dpi(0)                            -- Generic name spacing (If show_generic_name)
+    app_name_halign = "center"                                        -- App name horizontal alignment
+    app_name_font = "Comic Sans"                                      -- App name font
+    app_name_normal_color = "#FFFFFF"                                 -- App name normal color
+    app_name_selected_color = "#000000"                               -- App name selected color
+    app_show_generic_name = true                                      -- Should show generic app name?
+}
+```

--- a/docs/widgets/app_launcher.md
+++ b/docs/widgets/app_launcher.md
@@ -35,10 +35,10 @@ local app_launcher = bling.widget.app_launcher(args)
 ```lua
 local args = {
     terminal = "alacritty"                                            -- Set default terminal
-    favorites = { "wezterm" }                                         -- Favorites are given priority and are bubbled to top of the list
-    search_commands = { "" }                                          --  
+    favorites = { "firefox", "wezterm" }                              -- Favorites are given priority and are bubbled to top of the list
+    search_commands = true                                            -- Search by app name AND commandline command
     skip_names = { "Discord" }                                        -- List of apps to omit from launcher
-    skip_commands = { "" }                                            -- 
+    skip_commands = { "thunar" }                                      -- List of commandline commands to omit from launcher
     skip_empty_icons = true                                           -- Skip applications without icons
     sort_alphabetically = true                                        -- Sorts applications alphabetically
     reverse_sort_alphabetically = false                               -- Sort in reverse alphabetical order (NOTE: must set `sort_alphabetically = false` to take effect)
@@ -48,21 +48,21 @@ local args = {
     hide_on_launch = true                                             -- Hide launcher when spawning application
     try_to_keep_index_after_searching = false                         -- After a search, reselect the previously selected app
     reset_on_hide = true                                              -- When you hide the launcher, reset search query
-    save_history = true                                               -- 
+    save_history = true                                               -- Save search history
     wrap_page_scrolling = true                                        -- Allow scrolling to wrap back to beginning/end of launcher list
-    wrap_app_scrolling = true                                         -- 
+    wrap_app_scrolling = true                                         -- Set app scrolling 
 
-    default_app_icon_name = ""                                        -- Sets default app icon name for apps without icon names
-    default_app_icon_path = ""                                        -- Sets default app icon path for apps without icon paths
-    icon_theme = ""                                                   -- Set icon theme
-    icons_size = ""                                                   -- Set icon size
+    default_app_icon_name = "standard.svg"                            -- Sets default app icon name for apps without icon names
+    default_app_icon_path = "~/icons/"                                -- Sets default app icon path for apps without icon paths
+    icon_theme = "application"                                        -- Set icon theme
+    icon_size = 24                                                    -- Set icon size
 
     type = "dock"                                                     -- awful.popup type ("dock", "desktop", "normal"...).  See awesomewm docs for more detail
     show_on_focused_screen = true                                     -- Should app launcher show on currently focused screen
     screen = awful.screen                                             -- Screen you want the launcher to launch to
     placement = awful.placement.top_left                              -- Where launcher should be placed ("awful.placement.centered").
-    rubato =                                                          -- 
-    shirnk_width = true                                               -- Automatically shrink width of launcher to fit varying numbers of apps in list (works on apps_per_column)
+    rubato = { x = rubato_animation_x, y = rubato_animation_y }       -- Rubato animation to apply to launcher
+    shrink_width = true                                               -- Automatically shrink width of launcher to fit varying numbers of apps in list (works on apps_per_column)
     shrink_height = true                                              -- Automatically shrink height of launcher to fit varying numbers of apps in list (works on apps_per_row)
     background = "#FFFFFF"                                            -- Set bg color
     shape = function(cr, width, height)
@@ -89,7 +89,7 @@ local args = {
         args.prompt_icon_color, args.prompt_icon
     )                                                                 -- Prompt icon markup
     prompt_text = "<b>Search</b>:"                                    -- Prompt text
-    prompt_start_text = ""                                            -- Set string for prompt to start with
+    prompt_start_text = "manager"                                     -- Set string for prompt to start with
     prompt_font = "Comic Sans"                                        -- Prompt font
     prompt_text_color = "#FFFFFF"                                     -- Prompt text color
     prompt_cursor_color = "#000000"                                   -- Prompt cursor color
@@ -99,7 +99,7 @@ local args = {
     apps_margin = {left = dpi(40), right = dpi(40), bottom = dpi(30)} -- Margin between apps
     apps_spacing = dpi(10)                                            -- Spacing between apps
     
-    expand_apps = true                                                --
+    expand_apps = true                                                -- Should apps expand to fill width of launcher
     app_width = dpi(400)                                              -- Width of each app
     app_height = dpi(40)                                              -- Height of each app
     app_shape = function(cr, width, height)

--- a/widget/app_launcher/init.lua
+++ b/widget/app_launcher/init.lua
@@ -770,14 +770,14 @@ local function new(args)
     args.default_app_icon_name = args.default_app_icon_name or nil
     args.default_app_icon_path = args.default_app_icon_path or nil
     args.icon_theme = args.icon_theme or nil
-    args.icons_size = args.icons_size or nil
+    args.icon_size = args.icon_size or nil
 
     args.type = args.type or "dock"
     args.show_on_focused_screen = args.show_on_focused_screen == nil and true or args.show_on_focused_screen
     args.screen = args.screen or capi.screen.primary
     args.placement = args.placement or awful.placement.centered
     args.rubato = args.rubato or nil
-    args.shirnk_width = args.shirnk_width ~= nil and args.shirnk_width or false
+    args.shrink_width = args.shrink_width ~= nil and args.shrink_width or false
     args.shrink_height = args.shrink_height ~= nil and args.shrink_height or false
     args.background = args.background or "#000000"
     args.shape = args.shape or nil
@@ -842,7 +842,7 @@ local function new(args)
     gtable.crush(ret, args)
 
     -- Calculate the grid width and height
-    local grid_width = ret.shirnk_width == false
+    local grid_width = ret.shrink_width == false
         and dpi((ret.app_width * ret.apps_per_column) + ((ret.apps_per_column - 1) * ret.apps_spacing))
         or nil
     local grid_height = ret.shrink_height == false


### PR DESCRIPTION
Refer to #130 

I was actually trying to implement something exactly like this myself without knowing it already existed.  Hopefully adding the docs will help someone else find it on the bling website.

Couple things in this documentation.

1) I wasn't sure the proper way to give a description of every option, some I left blank because I don't understand what the options do.  (save_history, the `commands` options, and the rubato option)
2) I noticed a typo on the `shrink_width` option, but I didn't want to fix it without running it by your team first.  The correct move would be to rename from `shirnk_width` to `shrink_width` but I don't know the downstream effects or how you normally disseminate breaking changes like that, so I left it as `shirnk_width` and documented it as such.  Should I add a more clear note in these docs letting end users know that it's not a typo in the docs, rather the real option name?
3) Do you want more images to demonstrate the options?  I wasn't sure so I just used the image @JavaCafe01 posted a little bit ago in one of the PRs (https://github.com/BlingCorp/bling/pull/103#issuecomment-960128253).

Let me know what I can improve on this, and thank you all so much for bling.