### PR TITLE
Playerctl module: Added extra metadata

### DIFF
--- a/layout/init.lua
+++ b/layout/init.lua
@@ -37,7 +37,9 @@ local layouts = {
 
 for _, layout_name in ipairs(layouts) do
     local icon_raw = get_layout_icon_path(layout_name)
-    beautiful["layout_" .. layout_name] = get_icon(icon_raw)
+    if beautiful["layout_" .. layout_name] == nil then 
+        beautiful["layout_" .. layout_name] = get_icon(icon_raw)
+    end
     M[layout_name] = require(... .. "." .. layout_name)
 end
 


### PR DESCRIPTION
I'll admit that the way i did it is not the greatest. I tried not to make it a breaking change.

An alternative solution would be giving access to `metadata.value` to the user directly, which would probably be a whole lot nicer as well.