### PR TITLE
Add app content layout in app_launcher

### DIFF
--- a/docs/widgets/app_launcher.md
+++ b/docs/widgets/app_launcher.md
@@ -112,6 +112,7 @@ local args = {
     app_normal_hover_color = "#111111"                                -- App normal hover color
     app_selected_color = "#FFFFFF"                                    -- App selected color
     app_selected_hover_color = "#EEEEEE"                              -- App selected hover color
+    app_content_layout = "vertical"|"horizontal"                      -- App content layout (for icon and app name)
     app_content_padding = dpi(10)                                     -- App content padding
     app_content_spacing = dpi(10)                                     -- App content spacing
     app_show_icon = true                                              -- Should show icon?

--- a/widget/app_launcher/init.lua
+++ b/widget/app_launcher/init.lua
@@ -171,7 +171,7 @@ local function create_app_widget(self, entry)
                 expand = "outside",
                 nil,
                 {
-                    layout = wibox.layout.fixed.vertical,
+                    layout = wibox.layout.fixed[self.app_content_layout] or wibox.layout.fixed.vertical,
                     spacing = self.app_content_spacing,
                     icon,
                     {
@@ -822,6 +822,7 @@ local function new(args)
     args.app_selected_hover_color = args.app_selected_hover_color or (color.is_dark(args.app_normal_color) or color.is_opaque(args.app_normal_color)) and
         color.rgba_to_hex(color.multiply(color.hex_to_rgba(args.app_selected_color), 2.5)) or
         color.rgba_to_hex(color.multiply(color.hex_to_rgba(args.app_selected_color), 0.5))
+    args.app_content_layout = args.app_content_layout or 'vertical'
     args.app_content_padding = args.app_content_padding or dpi(10)
     args.app_content_spacing = args.app_content_spacing or dpi(10)
     args.app_show_icon = args.app_show_icon == nil and true or args.app_show_icon


### PR DESCRIPTION
Add `app_content_layout` option to the app_launcher to allow styles such as the following:
![image](https://user-images.githubusercontent.com/104871514/213886952-6287f8bd-c50c-4c41-bb23-5ca3e3c13aea.png)

Falls back to a vertical layout if the given entry is invalid.