### PR TITLE
Centered layout for ultrawide screen

### DIFF
--- a/layout/centered.lua
+++ b/layout/centered.lua
@@ -16,9 +16,9 @@ function mylayout.arrange(p)
     local slave_width = 0.5 * (area.width - master_area_width)
     local master_area_x = area.x + slave_width
 
-
     -- Special case: few slaves -> make masters take more space - unless requested otherwise!
-    if nslaves < 2 and t.master_fill_policy ~= "master_width_factor" then
+    if nslaves < 2 and t.master_fill_policy ~= "master_width_factor" and
+        t.centered_layout_master_fill_policy ~= "master_width_factor" then
         master_area_x = area.x
 
         if nslaves == 1 then


### PR DESCRIPTION
Yes, there's the master_width_policy, but it's a prop you set per tag rather than per layout, and for me personally, and I'd guess others it only makes sense to have it set to 'master_width_factor' for the centered layout, and I don't want that option for my other layouts, especially when using an ultrawide. Making it a beautiful variable is also possible, but I thought this way is more consistent

Here's an example from my config on how I'm using it
```LUA
awful.screen.connect_for_each_screen(function(s)
    for i = 1, 8, 1  do
        awful.tag.add(i, {
            layout = awful.layout.layouts[1],
            centered_layout_master_fill_policy = "master_width_factor",
            screen = s,
            selected = i == 1 and true or false,
        })
    end
end)
```