### PR TITLE
Playerctl lib minor bug fixes

### DIFF
--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -521,8 +521,11 @@ local function new(args)
     -- Grab settings from beautiful variables if not set explicitly
     args.ignore = args.ignore or beautiful.playerctl_ignore
     args.player = args.player or beautiful.playerctl_player
-    ret.update_on_activity = args.update_on_activity or
-                              beautiful.playerctl_update_on_activity or true
+    if args.update_on_activity ~= nil then
+        ret.update_on_activity = args.update_on_activity
+    else
+        ret.update_on_activity = beautiful.playerctl_update_on_activity ~= false
+    end
     ret.interval = args.interval or beautiful.playerctl_position_update_interval or 1
     ret.debounce_delay = args.debounce_delay or beautiful.playerctl_debounce_delay or 0.35
     parse_args(ret, args)

--- a/signal/playerctl/playerctl_lib.lua
+++ b/signal/playerctl/playerctl_lib.lua
@@ -170,8 +170,8 @@ function playerctl:get_active_player()
 end
 
 function playerctl:get_player_of_name(name)
-    for _, player in ipairs(self._private.manager.players[1]) do
-        if player.name == name then
+    for _, player in ipairs(self._private.manager.players) do
+        if player.player_name == name then
             return player
         end
     end


### PR DESCRIPTION
Here are two minor bug fixes:
1. `get_player_of_name` - `name` property doesn't exist
2. `ret.update_on_activity` is always true (unfortunately boolean can't be used with multiple and/or for this)