### PR TITLE
Improve tabbar's layout with modern style

### DIFF
--- a/widget/tabbar/modern.lua
+++ b/widget/tabbar/modern.lua
@@ -131,9 +131,10 @@ local function create(c, focused_bool, buttons, inactive_bool)
         tab_content = wibox.widget({
             {
                 awful.widget.clienticon(c),
-                top = dpi(10),
+                top = dpi(6),
                 left = dpi(15),
-                bottom = dpi(10),
+                right = dpi(10),
+                bottom = dpi(6),
                 widget = wibox.container.margin,
             },
             text_temp,

--- a/widget/tabbar/modern.lua
+++ b/widget/tabbar/modern.lua
@@ -108,7 +108,7 @@ local function create(c, focused_bool, buttons, inactive_bool)
         },
         text_temp,
         nill,
-        expand = "none",
+        expand = "inside",
         layout = wibox.layout.align.horizontal,
     })
 
@@ -144,7 +144,7 @@ local function create(c, focused_bool, buttons, inactive_bool)
                 bottom = dpi(10),
                 widget = wibox.container.margin,
             },
-            expand = "none",
+            expand = "inside",
             layout = wibox.layout.align.horizontal,
         })
     end


### PR DESCRIPTION
Using `tabbed` module with `modern` style, if the title of the currently focused client is too long, the minimize-floating-close buttons are not displayed, as the following screenshot shows:
![Screenshot-2023-05-09-14-38-22](https://github.com/BlingCorp/bling/assets/3716870/3221392c-23a7-4f39-a8ad-8da3c0bcda56)

This work changes the layout so that the placement of the icon and the buttons take precedence over the placement of the title textbox. This way, the three elements are displayed correctly and the title is truncated as much as needed:
![Screenshot-2023-05-09-14-44-00](https://github.com/BlingCorp/bling/assets/3716870/1f28ec30-d669-4fd6-8af8-baf9c9b73fc8)

Moreover, as the screenshot shows, an extra margin has been added between the client icon and the title to prevent them to be stuck to each other.