### PR TITLE
feat: use the __index meta-method for dynamically requiring modules.

### DIFF
--- a/bling-dev-1.rockspec
+++ b/bling-dev-1.rockspec
@@ -29,9 +29,9 @@ build = {
        ["bling.helpers.client"] = "helpers/client.lua",
        ["bling.helpers.color"] = "helpers/color.lua",
        ["bling.helpers.filesystem"] = "helpers/filesystem.lua",
+       ["bling.helpers.icon_theme"] = "helpers/icon_theme.lua",
        ["bling.helpers.shape"] = "helpers/shape.lua",
        ["bling.helpers.time"] = "helpers/time.lua",
-	   ["bling.helpers.icon_theme"] = "helpers/icon_theme.lua",
        ["bling.layout"] = "layout/init.lua",
        ["bling.layout.centered"] = "layout/centered.lua",
        ["bling.layout.deck"] = "layout/deck.lua",
@@ -60,5 +60,7 @@ build = {
        ["bling.widget.tag_preview"] = "widget/tag_preview.lua",
        ["bling.widget.task_preview"] = "widget/task_preview.lua",
        ["bling.widget.window_switcher"] = "widget/window_switcher.lua",
+       ["bling.widget.app_launcher"] = "widget/app_launcher/init.lua",
+       ["bling.widget.app_launcher.prompt"] = "widget/app_launcher/prompt.lua",
    },
 }

--- a/helpers/init.lua
+++ b/helpers/init.lua
@@ -1,7 +1,6 @@
-return {
-    client = require(... .. ".client"),
-    color = require(... .. ".color"),
-    filesystem = require(... .. ".filesystem"),
-    shape = require(... .. ".shape"),
-    time = require(... .. ".time"),
-}
+local before = ...
+return setmetatable({}, {
+    __index = function(_, key)
+        return require(before .. "." .. key)
+    end,
+})

--- a/init.lua
+++ b/init.lua
@@ -2,10 +2,9 @@
      Bling
      Layouts, widgets and utilities for Awesome WM
 --]]
-return {
-    layout = require(... .. ".layout"),
-    module = require(... .. ".module"),
-    helpers = require(... .. ".helpers"),
-    signal = require(... .. ".signal"),
-    widget = require(... .. ".widget"),
-}
+local before = ...
+return setmetatable({}, {
+    __index = function(_, key)
+        return require(before .. "." .. key)
+    end,
+})

--- a/module/init.lua
+++ b/module/init.lua
@@ -1,8 +1,6 @@
-return {
-    window_swallowing = require(... .. ".window_swallowing"),
-    tiled_wallpaper = require(... .. ".tiled_wallpaper"),
-    wallpaper = require(... .. ".wallpaper"),
-    flash_focus = require(... .. ".flash_focus"),
-    tabbed = require(... .. ".tabbed"),
-    scratchpad = require(... .. ".scratchpad"),
-}
+local before = ...
+return setmetatable({}, {
+    __index = function(_, key)
+        return require(before .. "." .. key)
+    end,
+})

--- a/signal/init.lua
+++ b/signal/init.lua
@@ -1,3 +1,6 @@
-return {
-    playerctl = require(... .. ".playerctl"),
-}
+local before = ...
+return setmetatable({}, {
+    __index = function(_, key)
+        return require(before .. "." .. key)
+    end,
+})

--- a/widget/init.lua
+++ b/widget/init.lua
@@ -1,7 +1,6 @@
-return {
-    tag_preview = require(... .. ".tag_preview"),
-    task_preview = require(... .. ".task_preview"),
-    window_switcher = require(... .. ".window_switcher"),
-    tabbed_misc = require(... .. ".tabbed_misc"),
-    app_launcher = require(... .. ".app_launcher"),
-}
+local before = ...
+return setmetatable({}, {
+    __index = function(_, key)
+        return require(before .. "." .. key)
+    end,
+})


### PR DESCRIPTION
This will omit manual registration.

Additionally, add some more missing modules to `rockspec`.