### PR TITLE
Feature: App Launcher layout

### DIFF
--- a/docs/widgets/app_launcher.md
+++ b/docs/widgets/app_launcher.md
@@ -119,6 +119,7 @@ local args = {
     app_icon_width = dpi(70)                                          -- App icon wigth
     app_icon_height = dpi(70)                                         -- App icon height
     app_show_name = true                                              -- Should show app name?
+    app_name_layout = wibox.layout.fixed.vertical                     -- App name layout
     app_name_generic_name_spacing = dpi(0)                            -- Generic name spacing (If show_generic_name)
     app_name_halign = "center"                                        -- App name horizontal alignment
     app_name_font = "Comic Sans"                                      -- App name font

--- a/widget/app_launcher/init.lua
+++ b/widget/app_launcher/init.lua
@@ -171,7 +171,7 @@ local function create_app_widget(self, entry)
                 expand = "outside",
                 nil,
                 {
-                    layout = wibox.layout.fixed.vertical,
+                    layout = self.app_name_layout,
                     spacing = self.app_content_spacing,
                     icon,
                     {
@@ -829,6 +829,7 @@ local function new(args)
     args.app_icon_width = args.app_icon_width or dpi(70)
     args.app_icon_height = args.app_icon_height or dpi(70)
     args.app_show_name = args.app_show_name == nil and true or args.app_show_name
+    args.app_name_layout = args.app_name_layout or wibox.layout.fixed.vertical
     args.app_name_generic_name_spacing = args.app_name_generic_name_spacing or dpi(0)
     args.app_name_halign = args.app_name_halign or "center"
     args.app_name_font = args.app_name_font or beautiful.font


### PR DESCRIPTION
Just simply allows you to define the layout of the app name to allow it to be vertical with the icon (by default) or horizontal with the icon.

Visual example:
![image](https://github.com/BlingCorp/bling/assets/72527881/9a236521-b975-4c84-bb1f-994cf8c71bdf)
